### PR TITLE
Omit port 443 in URLs so HTTPS urls are cleaner

### DIFF
--- a/src/NuGet.Server/Core/Helpers.cs
+++ b/src/NuGet.Server/Core/Helpers.cs
@@ -22,7 +22,7 @@ namespace NuGet.Server
             var uriBuilder = new UriBuilder(currentUrl);
 
             var repositoryUrl = uriBuilder.Scheme + "://" + uriBuilder.Host;
-            if (uriBuilder.Port != 80)
+            if (uriBuilder.Port != 80 && uriBuilder.Port != 443)
             {
                 repositoryUrl += ":" + uriBuilder.Port;
             }


### PR DESCRIPTION
As the title says...

**Before** this PR:
![image](https://cloud.githubusercontent.com/assets/177608/13828803/4c058770-eba2-11e5-880e-db0604c99446.png)

---

**After** this PR:
![image](https://cloud.githubusercontent.com/assets/177608/13828807/51886942-eba2-11e5-8f7c-4d7188b6e022.png)
