### PR TITLE
Default to using the host header for request urls

### DIFF
--- a/src/NuGet.Server/Web.config
+++ b/src/NuGet.Server/Web.config
@@ -50,6 +50,12 @@
     Set enableFrameworkFiltering to true to enable filtering packages by their supported frameworks during search.
     -->
     <add key="enableFrameworkFiltering" value="false" />
+    
+    <!--
+    When running NuGet.Server in a NAT network, ASP.NET may embed the erver's internal IP address in the V2 feed.
+    Uncomment the following configuration entry to enable NAT support.
+    -->
+    <!-- <add key="aspnet:UseHostHeaderForRequestUrl" value="true" /> -->
   </appSettings>
   <system.web>
     <httpRuntime maxRequestLength="31457280" />


### PR DESCRIPTION
See https://github.com/NuGet/NuGetGallery/issues/2951

> Ran into an issue which turned out to be relatively simple to fix, but seemed unnecessary work.

> Running NuGet.Server in a NAT'ed network with a public IP which was different from the server's internal IP caused the atom feed to return its internal IP for all incoming requests and made it impossible to actually download the packages as user's couldn't access the server via the internal IP.

> After digging into it, I realized that simply adding an appSetting for "aspnet:UseHostHeaderForRequestUrl" set to "true" resolved the issue easily enough.

> It seems like it would be better to default this to true by default, or at the very least, add it to the web.config commented out with a description explaining it just to help others find this in the future.
