### PR TITLE
Fix maxRequestLength value

### DIFF
--- a/src/NuGet.Server/Web.config
+++ b/src/NuGet.Server/Web.config
@@ -66,7 +66,7 @@
       </system.Web>
   -->
   <system.web>
-    <httpRuntime maxRequestLength="31457280" />
+    <httpRuntime maxRequestLength="30720" />
     <compilation debug="true" targetFramework="4.6" />
   </system.web>
   <system.serviceModel>

--- a/src/NuGet.Server/Web.config
+++ b/src/NuGet.Server/Web.config
@@ -66,6 +66,7 @@
       </system.Web>
   -->
   <system.web>
+    <!-- maxRequestLength is specified in Kb -->
     <httpRuntime maxRequestLength="30720" />
     <compilation debug="true" targetFramework="4.6" />
   </system.web>
@@ -86,6 +87,7 @@
     </handlers>
     <security>
       <requestFiltering>
+        <!-- maxAllowedContentLength is specified in Bytes -->
         <requestLimits maxAllowedContentLength="31457280"/>
       </requestFiltering>
     </security>


### PR DESCRIPTION
Fixes https://github.com/NuGet/NuGetGallery/issues/3217 - NuGet.Server web.config has inconsistent default values for max upload size. 

From http://stackoverflow.com/questions/6327452/which-gets-priority-maxrequestlength-or-maxallowedcontentlength it seems that we should ideally set the `maxRequestLength` to be a smaller value than that of the `maxAllowedContentLength`, so that appropriate error handler can be invoked, application error vs IIS error.

Both values are now set to ~30Mb. Let me know if that is not the desired value for Nuget.Server.

/cc @xavierdecoster @maartenba @skofman1 @ryuyu @scottbommarito 