### PR TITLE
Add SemVer2.0 Support

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <config>
     <add key="repositorypath" value=".\packages" />
@@ -10,8 +10,11 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+    <add key="NuGet-Volatile" value="https://dotnet.myget.org/F/nuget-volatile" />
   </packageSources>
-  <disabledPackageSources />
+  <disabledPackageSources>
+    <add key="Microsoft and .NET" value="true" />
+  </disabledPackageSources>
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />
   </activePackageSource>

--- a/src/NuGet.Server.Core/NuGet.Server.Core.csproj
+++ b/src/NuGet.Server.Core/NuGet.Server.Core.csproj
@@ -40,8 +40,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Core">
-      <HintPath>..\..\packages\NuGet.Core.2.11.1\lib\net40-Client\NuGet.Core.dll</HintPath>
+    <Reference Include="NuGet.Core, Version=2.14.0.830, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Core.2.14.0-rtm-830\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/NuGet.Server.Core/packages.config
+++ b/src/NuGet.Server.Core/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
-  <package id="NuGet.Core" version="2.11.1" targetFramework="net46" />
+  <package id="NuGet.Core" version="2.14.0-rtm-830" targetFramework="net46" />
 </packages>

--- a/src/NuGet.Server/NuGet.Server.csproj
+++ b/src/NuGet.Server/NuGet.Server.csproj
@@ -45,9 +45,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.11.1.812, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Core.2.11.1\lib\net40-Client\NuGet.Core.dll</HintPath>
+    <Reference Include="NuGet.Core, Version=2.14.0.830, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Core.2.14.0-rtm-830\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RouteMagic, Version=1.3.0.0, Culture=neutral, PublicKeyToken=84b59be021aa4cee, processorArchitecture=MSIL">

--- a/src/NuGet.Server/packages.config
+++ b/src/NuGet.Server/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net46" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
-  <package id="NuGet.Core" version="2.11.1" targetFramework="net46" />
+  <package id="NuGet.Core" version="2.14.0-rtm-830" targetFramework="net46" />
   <package id="RouteMagic" version="1.3" targetFramework="net46" />
   <package id="WebActivatorEx" version="2.1.0" targetFramework="net46" />
 </packages>

--- a/test/NuGet.Server.Core.Tests/NormalizeVersionInterceptorTest.cs
+++ b/test/NuGet.Server.Core.Tests/NormalizeVersionInterceptorTest.cs
@@ -45,7 +45,46 @@ namespace NuGet.Server.Core.Tests
                             ExpressionType.Equal,
                             Expression.Constant("1.0.0"),
                             Expression.MakeMemberAccess(Expression.Parameter(typeof(ODataPackage)), _normalizedVersionMember))
-                    }
+                    },
+
+                    new object[]
+                    {
+                        Expression.MakeBinary(
+                            ExpressionType.Equal,
+                            Expression.MakeMemberAccess(Expression.Parameter(typeof(ODataPackage)), _versionMember),
+                            Expression.Constant("1.0.0-00test")),
+
+                        Expression.MakeBinary(
+                            ExpressionType.Equal,
+                            Expression.Constant("1.0.0-00test"),
+                            Expression.MakeMemberAccess(Expression.Parameter(typeof(ODataPackage)), _normalizedVersionMember))
+                    },
+
+                    new object[]
+                    {
+                        Expression.MakeBinary(
+                            ExpressionType.Equal,
+                            Expression.MakeMemberAccess(Expression.Parameter(typeof(ODataPackage)), _versionMember),
+                            Expression.Constant("1.0.0-00test+tagged")),
+
+                        Expression.MakeBinary(
+                            ExpressionType.Equal,
+                            Expression.Constant("1.0.0-00test"),
+                            Expression.MakeMemberAccess(Expression.Parameter(typeof(ODataPackage)), _normalizedVersionMember))
+                    },
+
+                    new object[]
+                    {
+                        Expression.MakeBinary(
+                            ExpressionType.Equal,
+                            Expression.MakeMemberAccess(Expression.Parameter(typeof(ODataPackage)), _versionMember),
+                            Expression.Constant("1.0.0+taggedOnly")),
+
+                        Expression.MakeBinary(
+                            ExpressionType.Equal,
+                            Expression.Constant("1.0.0"),
+                            Expression.MakeMemberAccess(Expression.Parameter(typeof(ODataPackage)), _normalizedVersionMember))
+                    },
                 };
             }
         }
@@ -70,6 +109,7 @@ namespace NuGet.Server.Core.Tests
             // Arrange
             var data = new List<ODataPackage>();
             data.Add(new ODataPackage { Id = "foo", Version = "1.0.0.0.0.0", NormalizedVersion = "1.0.0"});
+            data.Add(new ODataPackage { Id = "foo1", Version = "2.0.0+tagged", NormalizedVersion = "2.0.0" });
 
             var queryable = data.AsQueryable().InterceptWith(new NormalizeVersionInterceptor());
 
@@ -77,11 +117,17 @@ namespace NuGet.Server.Core.Tests
             var result1 = queryable.FirstOrDefault(p => p.Version == "1.0");
             var result2 = queryable.FirstOrDefault(p => p.Version == "1.0.0");
             var result3 = queryable.FirstOrDefault(p => p.Version == "1.0.0.0");
+            var result4 = queryable.FirstOrDefault(p => p.Version == "2.0");
+            var result5 = queryable.FirstOrDefault(p => p.Version == "2.0.0");
+            var result6 = queryable.FirstOrDefault(p => p.Version == "2.0.0+someOtherTag");
 
             // Assert
             Assert.Equal(result1, data[0]);
             Assert.Equal(result2, data[0]);
             Assert.Equal(result3, data[0]);
+            Assert.Equal(result4, data[1]);
+            Assert.Equal(result5, data[1]);
+            Assert.Equal(result6, data[1]);
         }
     }
 }

--- a/test/NuGet.Server.Core.Tests/NuGet.Server.Core.Tests.csproj
+++ b/test/NuGet.Server.Core.Tests/NuGet.Server.Core.Tests.csproj
@@ -41,9 +41,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.11.1.812, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Core.2.11.1\lib\net40-Client\NuGet.Core.dll</HintPath>
+    <Reference Include="NuGet.Core, Version=2.14.0.830, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Core.2.14.0-rtm-830\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/NuGet.Server.Core.Tests/SemanticVersionJsonConverterTests.cs
+++ b/test/NuGet.Server.Core.Tests/SemanticVersionJsonConverterTests.cs
@@ -33,10 +33,13 @@ namespace NuGet.Server.Core.Tests
         }
 
         [Theory]
-        [InlineData("1.0.0")]
-        [InlineData("2.0.0.0")]
-        [InlineData("3.0.0-alpha1")]
-        public void SerializesSemanticVersionAsString(string version)
+        [InlineData("1.0.0", "1.0.0")]
+        [InlineData("2.0.0.0", "2.0.0.0")]
+        [InlineData("3.0.0-alpha1", "3.0.0-alpha1")]
+        [InlineData("4.0.0-0test.zero", "4.0.0-0test.zero")]
+        [InlineData("4.0.0-0test.zero+tagParses", "4.0.0-0test.zero")]
+        [InlineData("4.0.0-test.more.parts+tagsHash", "4.0.0-test.more.parts")]
+        public void SerializesSemanticVersionAsString(string version, string expected)
         {
             // Arrange
             var json = new StringBuilder();
@@ -48,7 +51,7 @@ namespace NuGet.Server.Core.Tests
                 converter.WriteJson(writer, SemanticVersion.Parse(version), new JsonSerializer());
 
                 // Assert
-                Assert.Equal("\"" + version + "\"", json.ToString());
+                Assert.Equal("\"" + expected + "\"", json.ToString());
             }
         }
 
@@ -72,13 +75,21 @@ namespace NuGet.Server.Core.Tests
         }
 
         [Theory]
-        [InlineData("1.0.0", typeof(SemanticVersion))]
-        [InlineData("2.0.0.0", typeof(SemanticVersion))]
-        [InlineData("3.0.0-alpha", typeof(SemanticVersion))]
-        [InlineData("1.0.0", typeof(Version))]
-        [InlineData("2.0.0.0", typeof(Version))]
-        public void Deserializes(string version, Type type)
+        [InlineData("1.0.0", typeof(SemanticVersion), "1.0.0")]
+        [InlineData("2.0.0.0", typeof(SemanticVersion), "2.0.0.0")]
+        [InlineData("3.0.0-alpha", typeof(SemanticVersion), "3.0.0-alpha")]
+        [InlineData("4.0.0-0test.zero", typeof(SemanticVersion), "4.0.0-0test.zero")]
+        [InlineData("4.0.0-0test.zero+tagParses", typeof(SemanticVersion), "4.0.0-0test.zero")]
+        [InlineData("4.0.0-test.more.parts+tagsHash", typeof(SemanticVersion), "4.0.0-test.more.parts")]
+        [InlineData("1.0.0", typeof(Version), "1.0.0")]
+        [InlineData("2.0.0.0", typeof(Version), "2.0.0.0")]
+        public void Deserializes(string version, Type type, string expected=null)
         {
+            if (expected == null)
+            {
+                expected = version;
+            }
+
             // Arrange
             using (var reader = new JsonTextReader(new StringReader("\"" + version + "\"")))
             {
@@ -88,7 +99,7 @@ namespace NuGet.Server.Core.Tests
                 var result = converter.ReadJson(reader, type, null, new JsonSerializer());
 
                 // Assert
-                Assert.Equal(version, result.ToString());
+                Assert.Equal(expected, result.ToString());
             }
         }
     }

--- a/test/NuGet.Server.Core.Tests/SemanticVersionJsonConverterTests.cs
+++ b/test/NuGet.Server.Core.Tests/SemanticVersionJsonConverterTests.cs
@@ -81,15 +81,11 @@ namespace NuGet.Server.Core.Tests
         [InlineData("4.0.0-0test.zero", typeof(SemanticVersion), "4.0.0-0test.zero")]
         [InlineData("4.0.0-0test.zero+tagParses", typeof(SemanticVersion), "4.0.0-0test.zero")]
         [InlineData("4.0.0-test.more.parts+tagsHash", typeof(SemanticVersion), "4.0.0-test.more.parts")]
+        [InlineData("4.0.0+tagsOnly", typeof(SemanticVersion), "4.0.0")]
         [InlineData("1.0.0", typeof(Version), "1.0.0")]
         [InlineData("2.0.0.0", typeof(Version), "2.0.0.0")]
         public void Deserializes(string version, Type type, string expected=null)
         {
-            if (expected == null)
-            {
-                expected = version;
-            }
-
             // Arrange
             using (var reader = new JsonTextReader(new StringReader("\"" + version + "\"")))
             {

--- a/test/NuGet.Server.Core.Tests/packages.config
+++ b/test/NuGet.Server.Core.Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net46" />
   <package id="Moq" version="4.5.8" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
-  <package id="NuGet.Core" version="2.11.1" targetFramework="net46" />
+  <package id="NuGet.Core" version="2.14.0-rtm-830" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/test/NuGet.Server.Tests/NuGet.Server.Tests.csproj
+++ b/test/NuGet.Server.Tests/NuGet.Server.Tests.csproj
@@ -41,9 +41,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.11.1.812, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Core.2.11.1\lib\net40-Client\NuGet.Core.dll</HintPath>
+    <Reference Include="NuGet.Core, Version=2.14.0.830, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Core.2.14.0-rtm-830\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/NuGet.Server.Tests/packages.config
+++ b/test/NuGet.Server.Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net46" />
   <package id="Moq" version="4.5.8" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
-  <package id="NuGet.Core" version="2.11.1" targetFramework="net46" />
+  <package id="NuGet.Core" version="2.14.0-rtm-830" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />


### PR DESCRIPTION
Update NuGet.Core reference to 2.14 for server 2.0
Expand semver tests to include semver 2.0 type versions.

@emgarten @shishirx34 @maartenba @xavierdecoster 


