### PR TITLE
Pack NuGet.Server from .nuspec instead of .csproj to control content subdirectory (net46)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,4 @@ DebugConstants.cs
 *.userprefs
 src/VsExtension/source.extension.vsixmanifest
 !packages/Microsoft.Web.Xdt.1.0.0-alpha/
+*.cache.bin

--- a/build.cmd
+++ b/build.cmd
@@ -7,6 +7,8 @@ if "%config%" == "" (
 set version=
 if not "%PackageVersion%" == "" (
    set version=-Version %PackageVersion%
+) else (
+   set version=-Version 1.0.0-build
 )
 
 
@@ -37,7 +39,7 @@ IF %ERRORLEVEL% NEQ 0 goto error
 REM Package
 mkdir artifacts
 mkdir artifacts\packages
-call :ExecuteCmd tools\nuget.exe pack "src\NuGet.Server\NuGet.Server.csproj" -symbols -o artifacts\packages -p Configuration=%config% %version%
+call :ExecuteCmd tools\nuget.exe pack "src\NuGet.Server\NuGet.Server.nuspec" -symbols -o artifacts\packages -p Configuration=%config% %version%
 IF %ERRORLEVEL% NEQ 0 goto error
 
 

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -13,7 +13,7 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible(false)]
 
-[assembly: AssemblyVersion("2.11.3.0")]
-[assembly: AssemblyFileVersion("2.11.3.0")]
+[assembly: AssemblyVersion("2.14.0.0")]
+[assembly: AssemblyFileVersion("2.14.0.0")]
 
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -13,7 +13,7 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible(false)]
 
-[assembly: AssemblyVersion("2.11.2.0")]
-[assembly: AssemblyFileVersion("2.11.2.0")]
+[assembly: AssemblyVersion("2.11.3.0")]
+[assembly: AssemblyFileVersion("2.11.3.0")]
 
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/src/NuGet.Server/NuGet.Server.csproj
+++ b/src/NuGet.Server/NuGet.Server.csproj
@@ -40,14 +40,12 @@
       <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.11.1.812, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Core.2.11.1\lib\net40-Client\NuGet.Core.dll</HintPath>
+    <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RouteMagic, Version=1.3.0.0, Culture=neutral, PublicKeyToken=84b59be021aa4cee, processorArchitecture=MSIL">
@@ -71,8 +69,7 @@
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="WebActivatorEx, Version=2.0.0.0, Culture=neutral, PublicKeyToken=7b26dc2a43f6a0d4, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\WebActivatorEx.2.1.0\lib\net40\WebActivatorEx.dll</HintPath>
+      <HintPath>..\..\packages\WebActivatorEx.2.2.0\lib\net40\WebActivatorEx.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WindowsBase" />

--- a/src/NuGet.Server/NuGet.Server.nuspec
+++ b/src/NuGet.Server/NuGet.Server.nuspec
@@ -1,23 +1,46 @@
 <?xml version="1.0"?>
 <package>
   <metadata minClientVersion="2.6">
-    <id>$id$</id>
+    <id>NuGet.Server</id>
     <version>$version$</version>
-    <description>$description$</description>
+    <description>Web Application used to host a simple NuGet feed</description>
     <authors>.NET Foundation</authors>
-    <owners>$author$</owners>
+    <owners>.NET Foundation</owners>
     <licenseUrl>https://raw.githubusercontent.com/NuGet/NuGet.Server/dev/LICENSE.txt</licenseUrl>
     <projectUrl>https://github.com/NuGet/NuGet.Server</projectUrl>
-    <copyright>$copyright$</copyright>
+    <copyright>© .NET Foundation. All rights reserved.</copyright>
     <frameworkAssemblies>
-      <frameworkAssembly assemblyName="System.ServiceModel" />
-      <frameworkAssembly assemblyName="System.ServiceModel.Web" />
-      <frameworkAssembly assemblyName="System.ServiceModel.Activation" />
-      <frameworkAssembly assemblyName="System.Data.Services" />
+      <frameworkAssembly assemblyName="System.ServiceModel" targetFramework="net46" />
+      <frameworkAssembly assemblyName="System.ServiceModel.Web" targetFramework="net46" />
+      <frameworkAssembly assemblyName="System.ServiceModel.Activation" targetFramework="net46" />
+      <frameworkAssembly assemblyName="System.Data.Services" targetFramework="net46" />
     </frameworkAssemblies>
     <dependencies>
-      <dependency id="NuGet.Core" version="[2.11.1,)" />
-      <dependency id="Microsoft.Web.Xdt" version="[2.1.1,)" />
+      <group targetFramework="net46">
+        <dependency id="NuGet.Core" version="[2.11.1,)" />
+        <dependency id="Microsoft.Web.Xdt" version="[2.1.1,)" />
+        <dependency id="Newtonsoft.Json" version="8.0.3" />
+        <dependency id="RouteMagic" version="1.3" />
+        <dependency id="WebActivatorEx" version="2.1.0" />
+      </group>
     </dependencies>
   </metadata>
+  <files>
+    <!-- lib\net46 -->
+    <file src="bin\NuGet.Server.dll" target="lib\net46" />
+    <file src="bin\NuGet.Server.pdb" target="lib\net46" />
+    
+    <!-- content\net46 -->
+    <file src="DataServices\Packages.svc" target="content\net46\DataServices" />
+    <file src="DataServices\Routes.cs.pp" target="content\net46\DataServices" />
+    <file src="Packages\Readme.txt" target="content\net46\Packages" />
+    <file src="Default.aspx" target="content\net46" />
+    <file src="favicon.ico" target="content\net46" />
+    <file src="web.config.install.xdt" target="content\net46" />
+    <file src="Web.config" target="content\net46" />
+    
+    <!-- src -->
+    <file src="**\*.cs" target="src" exclude="**\obj\**\*.cs" />
+    <file src="..\CommonAssemblyInfo.cs" target="src\Properties" />
+  </files>
 </package>

--- a/src/NuGet.Server/NuGet.Server.nuspec
+++ b/src/NuGet.Server/NuGet.Server.nuspec
@@ -17,11 +17,11 @@
     </frameworkAssemblies>
     <dependencies>
       <group targetFramework="net46">
-        <dependency id="NuGet.Core" version="[2.11.1,)" />
-        <dependency id="Microsoft.Web.Xdt" version="[2.1.1,)" />
-        <dependency id="Newtonsoft.Json" version="8.0.3" />
-        <dependency id="RouteMagic" version="1.3" />
-        <dependency id="WebActivatorEx" version="2.1.0" />
+        <dependency id="NuGet.Core" version="2.14.0" />
+        <dependency id="Microsoft.Web.Xdt" version="2.1.1" />
+        <dependency id="Newtonsoft.Json" version="9.0.1" />
+        <dependency id="RouteMagic" version="1.3.0" />
+        <dependency id="WebActivatorEx" version="2.2.0" />
       </group>
     </dependencies>
   </metadata>

--- a/src/NuGet.Server/packages.config
+++ b/src/NuGet.Server/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net46" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
-  <package id="NuGet.Core" version="2.11.1" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
+  <package id="NuGet.Core" version="2.14.0" targetFramework="net46" />
   <package id="RouteMagic" version="1.3" targetFramework="net46" />
-  <package id="WebActivatorEx" version="2.1.0" targetFramework="net46" />
+  <package id="WebActivatorEx" version="2.2.0" targetFramework="net46" />
 </packages>

--- a/test/NuGet.Server.Tests/NuGet.Server.Tests.csproj
+++ b/test/NuGet.Server.Tests/NuGet.Server.Tests.csproj
@@ -35,14 +35,12 @@
       <HintPath>..\..\packages\Moq.4.5.8\lib\net45\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.11.1.812, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Core.2.11.1\lib\net40-Client\NuGet.Core.dll</HintPath>
+    <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/NuGet.Server.Tests/packages.config
+++ b/test/NuGet.Server.Tests/packages.config
@@ -3,8 +3,8 @@
   <package id="Castle.Core" version="3.3.3" targetFramework="net46" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net46" />
   <package id="Moq" version="4.5.8" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
-  <package id="NuGet.Core" version="2.11.1" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
+  <package id="NuGet.Core" version="2.14.0" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />


### PR DESCRIPTION
.nupkg directory structure change:
```
content\Default.aspx                -->   content\net46\Default.aspx
content\favicon.ico                 -->   content\net46\favicon.ico
content\Packages                    -->   content\net46\Packages
content\Web.config                  -->   content\net46\Web.config
content\web.config.install.xdt      -->   content\net46\web.config.install.xdt
content\DataServices\Packages.svc   -->   content\net46\DataServices\Packages.svc
content\DataServices\Routes.cs.pp   -->   content\net46\DataServices\Routes.cs.pp
content\Packages\Readme.txt         -->   content\net46\Packages\Readme.txt
lib\net46\NuGet.Server.dll          -->   lib\net46\NuGet.Server.dll
```

Needed to pack a .nuspec for NuGet.Server instead of a .csproj so we can set the content files to go to `content/net46`.

Fixes https://github.com/NuGet/NuGetGallery/issues/3257

/cc @emgarten @xavierdecoster @maartenba 