### PR TITLE
Make packages only net46 compatible (which matches the DLLs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,4 @@ DebugConstants.cs
 src/VsExtension/source.extension.vsixmanifest
 !packages/Microsoft.Web.Xdt.1.0.0-alpha/
 src/NuGet.Server/packages/*.bin
+*.cache.bin

--- a/NuGet.Server.sln
+++ b/NuGet.Server.sln
@@ -1,14 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{E7B39EAD-EA32-4011-845A-C949A336389A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A2E61590-0069-4746-A44D-4B2B805EDD91}"
 	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
 		build.cmd = build.cmd
 		CodeAnalysisDictionary.xml = CodeAnalysisDictionary.xml
+		NuGet.config = NuGet.config
 		NuGet.ruleset = NuGet.ruleset
 	EndProjectSection
 EndProject

--- a/NuGet.config
+++ b/NuGet.config
@@ -10,7 +10,6 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
-    <add key="NuGet-Volatile" value="https://dotnet.myget.org/F/nuget-volatile" />
   </packageSources>
   <disabledPackageSources>
     <add key="Microsoft and .NET" value="true" />

--- a/build.cmd
+++ b/build.cmd
@@ -37,9 +37,9 @@ REM Test
 call :ExecuteCmd tools\nuget.exe install xunit.runner.console -Version 2.1.0 -OutputDirectory packages
 call :ExecuteCmd packages\xunit.runner.console.2.1.0\tools\xunit.console.exe test\NuGet.Server.Core.Tests\bin\%config%\NuGet.Server.Core.Tests.dll
 IF %ERRORLEVEL% NEQ 0 goto error
-call :ExecuteCmd packages\xunit.runner.console.2.1.0\tools\xunit.console.exe test\NuGet.Server.Tests\bin\%config%\NuGet.Server.Tests.dll
-IF %ERRORLEVEL% NEQ 0 goto error
 call :ExecuteCmd packages\xunit.runner.console.2.1.0\tools\xunit.console.exe test\NuGet.Server.V2.Tests\bin\%config%\NuGet.Server.V2.Tests.dll
+IF %ERRORLEVEL% NEQ 0 goto error
+call :ExecuteCmd packages\xunit.runner.console.2.1.0\tools\xunit.console.exe test\NuGet.Server.Tests\bin\%config%\NuGet.Server.Tests.dll
 IF %ERRORLEVEL% NEQ 0 goto error
 
 
@@ -48,9 +48,9 @@ mkdir artifacts
 mkdir artifacts\packages
 call :ExecuteCmd tools\nuget.exe pack "src\NuGet.Server.Core\NuGet.Server.Core.csproj" -symbols -o artifacts\packages -p Configuration=%config% %versionPlaceholder% %version%
 IF %ERRORLEVEL% NEQ 0 goto error
-call :ExecuteCmd tools\nuget.exe pack "src\NuGet.Server\NuGet.Server.csproj" -symbols -o artifacts\packages -p Configuration=%config% %versionPlaceholder% %version%
-IF %ERRORLEVEL% NEQ 0 goto error
 call :ExecuteCmd tools\nuget.exe pack "src\NuGet.Server.V2\NuGet.Server.V2.csproj" -symbols -o artifacts\packages -p Configuration=%config% %versionPlaceholder% %version%
+IF %ERRORLEVEL% NEQ 0 goto error
+call :ExecuteCmd tools\nuget.exe pack "src\NuGet.Server\NuGet.Server.nuspec" -symbols -o artifacts\packages -p Configuration=%config% %versionPlaceholder% %version%
 IF %ERRORLEVEL% NEQ 0 goto error
 
 

--- a/samples/NuGet.Server.V2.Samples.OwinHost/NuGet.Server.V2.Samples.OwinHost.csproj
+++ b/samples/NuGet.Server.V2.Samples.OwinHost/NuGet.Server.V2.Samples.OwinHost.csproj
@@ -67,13 +67,12 @@
       <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.14.0.830, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Core.2.14.0-rtm-830\lib\net40-Client\NuGet.Core.dll</HintPath>
+    <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Owin">

--- a/samples/NuGet.Server.V2.Samples.OwinHost/app.config
+++ b/samples/NuGet.Server.V2.Samples.OwinHost/app.config
@@ -25,7 +25,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/samples/NuGet.Server.V2.Samples.OwinHost/packages.config
+++ b/samples/NuGet.Server.V2.Samples.OwinHost/packages.config
@@ -11,8 +11,8 @@
   <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net461" />
-  <package id="NuGet.Core" version="2.14.0-rtm-830" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
+  <package id="NuGet.Core" version="2.14.0" targetFramework="net46" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="System.Spatial" version="5.7.0" targetFramework="net45" />
 </packages>

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -12,8 +12,8 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible(false)]
 
-[assembly: AssemblyVersion("2.14.0.0")]
-[assembly: AssemblyFileVersion("2.14.0.0")]
-[assembly: AssemblyInformationalVersion("2.14.0.0")]
+[assembly: AssemblyVersion("2.15.0.0")]
+[assembly: AssemblyFileVersion("2.15.0.0")]
+[assembly: AssemblyInformationalVersion("2.15.0.0")]
 
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/src/NuGet.Server.Core/NuGet.Server.Core.csproj
+++ b/src/NuGet.Server.Core/NuGet.Server.Core.csproj
@@ -35,13 +35,12 @@
       <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.14.0.830, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Core.2.14.0-rtm-830\lib\net40-Client\NuGet.Core.dll</HintPath>
+    <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/NuGet.Server.Core/NuGet.Server.Core.nuspec
+++ b/src/NuGet.Server.Core/NuGet.Server.Core.nuspec
@@ -10,12 +10,14 @@
     <projectUrl>https://github.com/NuGet/NuGet.Server</projectUrl>
     <copyright>$copyright$</copyright>
     <frameworkAssemblies>
-      <frameworkAssembly assemblyName="System.Data.Services" />
+      <frameworkAssembly assemblyName="System.Data.Services" targetFramework="net46" />
     </frameworkAssemblies>
     <dependencies>
-      <dependency id="Microsoft.Web.Xdt" version="[2.1.1,)" />
-      <dependency id="Newtonsoft.Json" version="[8.0.3,)" />
-      <dependency id="NuGet.Core" version="[2.14.0-rtm-830,)" />
+      <group targetFramework="net46">
+        <dependency id="Microsoft.Web.Xdt" version="2.1.1" />
+        <dependency id="Newtonsoft.Json" version="9.0.1" />
+        <dependency id="NuGet.Core" version="2.14.0" />
+      </group>
     </dependencies>
   </metadata>
 </package>

--- a/src/NuGet.Server.Core/packages.config
+++ b/src/NuGet.Server.Core/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
-  <package id="NuGet.Core" version="2.14.0-rtm-830" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
+  <package id="NuGet.Core" version="2.14.0" targetFramework="net46" />
 </packages>

--- a/src/NuGet.Server.V2/NuGet.Server.V2.csproj
+++ b/src/NuGet.Server.V2/NuGet.Server.V2.csproj
@@ -47,13 +47,12 @@
       <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.14.0.830, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Core.2.14.0-rtm-830\lib\net40-Client\NuGet.Core.dll</HintPath>
+    <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/NuGet.Server.V2/NuGet.Server.V2.nuspec
+++ b/src/NuGet.Server.V2/NuGet.Server.V2.nuspec
@@ -10,20 +10,22 @@
     <projectUrl>https://github.com/NuGet/NuGet.Server</projectUrl>
     <copyright>$copyright$</copyright>
     <frameworkAssemblies>
-      <frameworkAssembly assemblyName="System.Data.Services" />
+      <frameworkAssembly assemblyName="System.Data.Services" targetFramework="net46" />
     </frameworkAssemblies>
     <dependencies>
-      <dependency id="Microsoft.Web.Xdt" version="[2.1.1,)" />
-      <dependency id="Newtonsoft.Json" version="[8.0.3,)" />
-      <dependency id="NuGet.Core" version="[2.14.0-rtm-830,)" />
-      <dependency id="NuGet.Server.Core" version="$packageVersion$" />
+      <group targetFramework="net46">
+        <dependency id="Microsoft.Web.Xdt" version="2.1.1" />
+        <dependency id="Newtonsoft.Json" version="9.0.1" />
+        <dependency id="NuGet.Core" version="2.14.0" />
+        <dependency id="NuGet.Server.Core" version="$packageVersion$" />
 
-      <dependency id="Microsoft.AspNet.WebApi.Client" version="[5.2.3,)" />
-      <dependency id="Microsoft.AspNet.WebApi.Core" version="[5.2.3,)" />
-      <dependency id="Microsoft.AspNet.WebApi.OData" version="[5.7.0,)" />
-      <dependency id="Microsoft.Data.Edm" version="[5.7.0,)" />
-      <dependency id="Microsoft.Data.OData" version="[5.7.0,)" />
-      <dependency id="System.Spatial" version="[5.7.0,)" />
+        <dependency id="Microsoft.AspNet.WebApi.Client" version="5.2.3" />
+        <dependency id="Microsoft.AspNet.WebApi.Core" version="5.2.3" />
+        <dependency id="Microsoft.AspNet.WebApi.OData" version="5.7.0" />
+        <dependency id="Microsoft.Data.Edm" version="5.7.0" />
+        <dependency id="Microsoft.Data.OData" version="5.7.0" />
+        <dependency id="System.Spatial" version="5.7.0" />
+      </group>
     </dependencies>
   </metadata>
 </package>

--- a/src/NuGet.Server.V2/app.config
+++ b/src/NuGet.Server.V2/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/src/NuGet.Server.V2/packages.config
+++ b/src/NuGet.Server.V2/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
-  <package id="NuGet.Core" version="2.14.0-rtm-830" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
+  <package id="NuGet.Core" version="2.14.0" targetFramework="net46" />
   <package id="System.Spatial" version="5.7.0" targetFramework="net45" />
 </packages>

--- a/src/NuGet.Server/App_Start/NuGetODataConfig.cs
+++ b/src/NuGet.Server/App_Start/NuGetODataConfig.cs
@@ -5,7 +5,12 @@ using System.Web.Http;
 using System.Web.Http.Routing;
 using NuGet.Server.V2;
 
+// The consuming project executes this logic with its own copy of this class. This is done with a .pp file that is
+// added and transformed upon package install.
+#if DEBUG
 [assembly: WebActivatorEx.PreApplicationStartMethod(typeof(NuGet.Server.App_Start.NuGetODataConfig), "Start")]
+#endif
+
 namespace NuGet.Server.App_Start
 {
     public static class NuGetODataConfig

--- a/src/NuGet.Server/App_Start/NuGetODataConfig.cs.pp
+++ b/src/NuGet.Server/App_Start/NuGetODataConfig.cs.pp
@@ -1,7 +1,8 @@
 ﻿using System.Net.Http;
 using System.Web.Http;
-using NuGet.Server.V2;
 using System.Web.Http.Routing;
+using NuGet.Server;
+using NuGet.Server.V2;
 
 [assembly: WebActivatorEx.PreApplicationStartMethod(typeof($rootnamespace$.App_Start.NuGetODataConfig), "Start")]
 

--- a/src/NuGet.Server/NuGet.Server.csproj
+++ b/src/NuGet.Server/NuGet.Server.csproj
@@ -50,13 +50,12 @@
       <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.14.0.830, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Core.2.14.0-rtm-830\lib\net40-Client\NuGet.Core.dll</HintPath>
+    <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -98,8 +97,7 @@
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="WebActivatorEx, Version=2.0.0.0, Culture=neutral, PublicKeyToken=7b26dc2a43f6a0d4, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\WebActivatorEx.2.1.0\lib\net40\WebActivatorEx.dll</HintPath>
+      <HintPath>..\..\packages\WebActivatorEx.2.2.0\lib\net40\WebActivatorEx.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -137,7 +135,7 @@
     <None Include="NuGet.Server.nuspec">
       <SubType>Designer</SubType>
     </None>
-    <None Include="App_Start\NuGetODataConfig.cs.pp" />
+    <Content Include="App_Start\NuGetODataConfig.cs.pp" />
     <Content Include="web.config.install.xdt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -188,4 +186,8 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
+  <PropertyGroup>
+    <PostBuildEvent>REM Rename the Web.config file for packing.
+copy $(ProjectDir)Web.config $(TargetDir)Web.config.transform &gt;NUL</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/src/NuGet.Server/NuGet.Server.nuspec
+++ b/src/NuGet.Server/NuGet.Server.nuspec
@@ -1,25 +1,47 @@
 <?xml version="1.0"?>
 <package>
   <metadata minClientVersion="2.6">
-    <id>$id$</id>
+    <id>NuGet.Server</id>
     <version>$packageVersion$</version>
-    <description>$description$</description>
+    <description>Web Application used to host a simple NuGet feed</description>
     <authors>.NET Foundation</authors>
-    <owners>$author$</owners>
+    <owners>.NET Foundation</owners>
     <licenseUrl>https://raw.githubusercontent.com/NuGet/NuGet.Server/dev/LICENSE.txt</licenseUrl>
     <projectUrl>https://github.com/NuGet/NuGet.Server</projectUrl>
-    <copyright>$copyright$</copyright>
+    <copyright>© .NET Foundation. All rights reserved.</copyright>
     <frameworkAssemblies>
-      <frameworkAssembly assemblyName="System.ServiceModel" />
-      <frameworkAssembly assemblyName="System.ServiceModel.Web" />
-      <frameworkAssembly assemblyName="System.ServiceModel.Activation" />
-      <frameworkAssembly assemblyName="System.Data.Services" />
+      <frameworkAssembly assemblyName="System.ServiceModel" targetFramework="net46" />
+      <frameworkAssembly assemblyName="System.ServiceModel.Web" targetFramework="net46" />
+      <frameworkAssembly assemblyName="System.ServiceModel.Activation" targetFramework="net46" />
+      <frameworkAssembly assemblyName="System.Data.Services" targetFramework="net46" />
     </frameworkAssemblies>
     <dependencies>
-      <dependency id="Microsoft.Web.Xdt" version="[2.1.1,)" />
-      <dependency id="NuGet.Core" version="[2.14.0-rtm-830,)" />
-      <dependency id="NuGet.Server.Core" version="$packageVersion$" />
-      <dependency id="NuGet.Server.V2" version="$packageVersion$" />
+      <group targetFramework="net46">
+        <dependency id="Microsoft.Web.Xdt" version="2.1.1" />
+        <dependency id="NuGet.Core" version="2.14.0" />
+        <dependency id="NuGet.Server.Core" version="$packageVersion$" />
+        <dependency id="NuGet.Server.V2" version="$packageVersion$" />
+        <dependency id="Microsoft.AspNet.WebApi" version="5.2.3" />
+        <dependency id="Microsoft.AspNet.WebApi.OData" version="5.7.0" />
+        <dependency id="WebActivatorEx" version="2.2.0" />
+      </group>
     </dependencies>
   </metadata>
+  <files>
+    <!-- lib\net46 -->
+    <file src="bin\NuGet.Server.dll" target="lib\net46" />
+    <file src="bin\NuGet.Server.pdb" target="lib\net46" />
+    
+    <!-- content\net46 -->
+    <file src="App_Start\NuGetODataConfig.cs.pp" target="content\net46\App_Start" />
+    <file src="Packages\Readme.txt" target="content\net46\Packages" />
+    <file src="Default.aspx" target="content\net46" />
+    <file src="favicon.ico" target="content\net46" />
+    <file src="web.config.install.xdt" target="content\net46" />
+    <file src="bin\Web.config.transform" target="content\net46" />
+    
+    <!-- src -->
+    <file src="**\*.cs" target="src" />
+    <file src="..\CommonAssemblyInfo.cs" target="src\Properties" />
+  </files>
 </package>

--- a/src/NuGet.Server/Web.config
+++ b/src/NuGet.Server/Web.config
@@ -107,7 +107,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/src/NuGet.Server/packages.config
+++ b/src/NuGet.Server/packages.config
@@ -9,8 +9,8 @@
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net46" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net46" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
-  <package id="NuGet.Core" version="2.14.0-rtm-830" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
+  <package id="NuGet.Core" version="2.14.0" targetFramework="net46" />
   <package id="System.Spatial" version="5.7.0" targetFramework="net46" />
-  <package id="WebActivatorEx" version="2.1.0" targetFramework="net46" />
+  <package id="WebActivatorEx" version="2.2.0" targetFramework="net46" />
 </packages>

--- a/test/NuGet.Server.Core.Tests/NuGet.Server.Core.Tests.csproj
+++ b/test/NuGet.Server.Core.Tests/NuGet.Server.Core.Tests.csproj
@@ -35,13 +35,12 @@
       <HintPath>..\..\packages\Moq.4.5.21\lib\net45\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.14.0.830, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Core.2.14.0-rtm-830\lib\net40-Client\NuGet.Core.dll</HintPath>
+    <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/NuGet.Server.Core.Tests/packages.config
+++ b/test/NuGet.Server.Core.Tests/packages.config
@@ -3,8 +3,8 @@
   <package id="Castle.Core" version="3.3.3" targetFramework="net46" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net46" />
   <package id="Moq" version="4.5.21" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
-  <package id="NuGet.Core" version="2.14.0-rtm-830" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
+  <package id="NuGet.Core" version="2.14.0" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/test/NuGet.Server.Tests/NuGet.Server.Tests.csproj
+++ b/test/NuGet.Server.Tests/NuGet.Server.Tests.csproj
@@ -35,13 +35,12 @@
       <HintPath>..\..\packages\Moq.4.5.21\lib\net45\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.14.0.830, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Core.2.14.0-rtm-830\lib\net40-Client\NuGet.Core.dll</HintPath>
+    <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/NuGet.Server.Tests/app.config
+++ b/test/NuGet.Server.Tests/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/test/NuGet.Server.Tests/packages.config
+++ b/test/NuGet.Server.Tests/packages.config
@@ -3,8 +3,8 @@
   <package id="Castle.Core" version="3.3.3" targetFramework="net46" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net46" />
   <package id="Moq" version="4.5.21" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
-  <package id="NuGet.Core" version="2.14.0-rtm-830" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
+  <package id="NuGet.Core" version="2.14.0" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/test/NuGet.Server.V2.Tests/NuGet.Server.V2.Tests.csproj
+++ b/test/NuGet.Server.V2.Tests/NuGet.Server.V2.Tests.csproj
@@ -56,13 +56,12 @@
       <HintPath>..\..\packages\Moq.4.5.21\lib\net45\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.14.0.830, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Core.2.14.0-rtm-830\lib\net40-Client\NuGet.Core.dll</HintPath>
+    <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/NuGet.Server.V2.Tests/app.config
+++ b/test/NuGet.Server.V2.Tests/app.config
@@ -25,7 +25,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/test/NuGet.Server.V2.Tests/packages.config
+++ b/test/NuGet.Server.V2.Tests/packages.config
@@ -8,8 +8,8 @@
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net46" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net46" />
   <package id="Moq" version="4.5.21" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
-  <package id="NuGet.Core" version="2.14.0-rtm-830" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
+  <package id="NuGet.Core" version="2.14.0" targetFramework="net46" />
   <package id="System.Spatial" version="5.7.0" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />


### PR DESCRIPTION
1. Pack NuGet.Server from .nuspec instead of .csproj to control content subdirectory
1. Make NuGet.Server.Core and NuGet.Server.V2 have net46-only dependencies
1. Use the .pp file to initialize NuGet.Server routes, instead of web activator in NuGet.Server.dll. This is like NuGet.Server 2.11.2.
1. Bump dependency versions.

This PR is analogous to https://github.com/NuGet/NuGet.Server/pull/21 but is against `dev` instead of `master`.

Open questions:
1. Should we bump the major version of NuGet.Server to signal to users that we've moved to WebAPI?

/cc @emgarten @xavierdecoster @maartenba @andulv