### PR TITLE
Minor bug fixes in NuGet.Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,7 +196,9 @@ FakesAssemblies/
 
 *.orig
 *.vs10x
-src/Server/Packages/*.nupkg
+src/NuGet.Server/Packages/**/*.nupkg
+src/NuGet.Server/Packages/**/*.sha512
+src/NuGet.Server/Packages/**/*.nuspec
 src/Server/Server.Publish.xml
 DebugConstants.cs
 *.log

--- a/src/NuGet.Server/DataServices/PackageExtensions.cs
+++ b/src/NuGet.Server/DataServices/PackageExtensions.cs
@@ -19,6 +19,8 @@ namespace NuGet.Server.DataServices
                 return AsODataPackage(serverPackage);
             }
 
+            var utcNow = DateTime.UtcNow;
+
             return new ODataPackage
             {
                 Id = package.Id,
@@ -37,8 +39,8 @@ namespace NuGet.Server.DataServices
                 Description = package.Description,
                 Summary = package.Summary,
                 ReleaseNotes = package.ReleaseNotes,
-                Published = package.Published.HasValue ? package.Published.Value.UtcDateTime : DateTime.UtcNow,
-                LastUpdated = package.Published.HasValue ? package.Published.Value.UtcDateTime : DateTime.UtcNow,
+                Published = package.Published.HasValue ? package.Published.Value.UtcDateTime : utcNow,
+                LastUpdated = package.Published.HasValue ? package.Published.Value.UtcDateTime : utcNow,
                 Dependencies = string.Join("|", package.DependencySets.SelectMany(ConvertDependencySetToStrings)),
                 PackageHash = package.GetHash(Constants.HashAlgorithm),
                 PackageHashAlgorithm = Constants.HashAlgorithm,
@@ -74,7 +76,7 @@ namespace NuGet.Server.DataServices
                 Description = package.Description,
                 Summary = package.Summary,
                 ReleaseNotes = package.ReleaseNotes,
-                Published = package.Published.HasValue ? package.Published.Value.UtcDateTime : DateTime.UtcNow,
+                Published = package.Created.UtcDateTime,
                 LastUpdated = package.LastUpdated.UtcDateTime,
                 Dependencies = string.Join("|", package.DependencySets.SelectMany(ConvertDependencySetToStrings)),
                 PackageHash = package.PackageHash,

--- a/src/NuGet.Server/Infrastructure/ServerPackage.cs
+++ b/src/NuGet.Server/Infrastructure/ServerPackage.cs
@@ -99,9 +99,10 @@ namespace NuGet.Server.Infrastructure
             FullPath = packageDerivedData.FullPath;
         }
 
+        [JsonRequired]
         public string Id { get; set; }
 
-        [JsonConverter(typeof(SemanticVersionJsonConverter))]
+        [JsonRequired, JsonConverter(typeof(SemanticVersionJsonConverter))]
         public SemanticVersion Version { get; set; }
 
         public string Title { get; set; }

--- a/src/NuGet.Server/Infrastructure/ServerPackageStore.cs
+++ b/src/NuGet.Server/Infrastructure/ServerPackageStore.cs
@@ -56,7 +56,7 @@ namespace NuGet.Server.Infrastructure
                     }
                     catch (Exception ex)
                     {
-                        if (ex is JsonReaderException || ex is SerializationException)
+                        if (ex is JsonException || ex is SerializationException)
                         {
                             // In case this happens, remove the file
                             _fileSystem.DeleteFile(_fileName);

--- a/test/NuGet.Server.Tests/NuGet.Server.Tests.csproj
+++ b/test/NuGet.Server.Tests/NuGet.Server.Tests.csproj
@@ -11,8 +11,6 @@
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/test/NuGet.Server.Tests/NuGet.Server.Tests.csproj
+++ b/test/NuGet.Server.Tests/NuGet.Server.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\NuGet.Settings.targets" />
   <PropertyGroup>
     <ProjectGuid>{92D18050-3867-4E39-B305-9F9870F66F5E}</ProjectGuid>
@@ -10,6 +11,8 @@
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -90,6 +93,7 @@
     <Compile Include="HelpersTest.cs" />
     <Compile Include="SemanticVersionJsonConverterTests.cs" />
     <Compile Include="ServerPackageRepositoryTest.cs" />
+    <Compile Include="ServerPackageStoreTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\NuGet.Server\NuGet.Server.csproj">
@@ -104,4 +108,10 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
 </Project>

--- a/test/NuGet.Server.Tests/ServerPackageStoreTest.cs
+++ b/test/NuGet.Server.Tests/ServerPackageStoreTest.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using System.IO;
+using System.Text;
+using Moq;
+using NuGet.Server.Infrastructure;
+using Xunit;
+
+namespace NuGet.Server.Tests
+{
+    public class ServerPackageStoreTest
+    {
+        [Theory]
+        [InlineData("[")]
+        [InlineData("]")]
+        [InlineData("{")]
+        [InlineData("}")]
+        [InlineData("[{")]
+        [InlineData("[{}")]
+        [InlineData("{}")]
+        [InlineData("[{\"foo\": \"bar\"}]")]
+        public void Constructor_IgnoresAndDeletesInvalidCacheFile(string content)
+        {
+            // Arrange
+            var fileName = "store.json";
+            var fileSystem = new Mock<IFileSystem>();
+            fileSystem
+                .Setup(x => x.FileExists(fileName))
+                .Returns(true);
+            fileSystem
+                .Setup(x => x.OpenFile(fileName))
+                .Returns(() => new MemoryStream(Encoding.UTF8.GetBytes(content)));
+
+            // Act
+            var actual = new ServerPackageStore(fileSystem.Object, fileName);
+
+            // Assert
+            Assert.Empty(actual.GetAll());
+            fileSystem.Verify(x => x.DeleteFile(fileName), Times.Once);
+        }
+    }
+}

--- a/test/NuGet.Server.Tests/ServerPackageStoreTest.cs
+++ b/test/NuGet.Server.Tests/ServerPackageStoreTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
 
 using System.IO;
+using System.Linq;
 using System.Text;
 using Moq;
 using NuGet.Server.Infrastructure;
@@ -38,6 +39,29 @@ namespace NuGet.Server.Tests
             // Assert
             Assert.Empty(actual.GetAll());
             fileSystem.Verify(x => x.DeleteFile(fileName), Times.Once);
+        }
+
+        [Theory]
+        [InlineData("[]", 0)]
+        [InlineData("[{\"Id\":\"NuGet.Versioning\",\"Version\":\"3.5.0\"}]", 1)]
+        public void Constructor_LeavesValidCacheFile(string content, int count)
+        {
+            // Arrange
+            var fileName = "store.json";
+            var fileSystem = new Mock<IFileSystem>();
+            fileSystem
+                .Setup(x => x.FileExists(fileName))
+                .Returns(true);
+            fileSystem
+                .Setup(x => x.OpenFile(fileName))
+                .Returns(() => new MemoryStream(Encoding.UTF8.GetBytes(content)));
+
+            // Act
+            var actual = new ServerPackageStore(fileSystem.Object, fileName);
+
+            // Assert
+            Assert.Equal(count, actual.GetAll().Count());
+            fileSystem.Verify(x => x.DeleteFile(It.IsAny<string>()), Times.Never);
         }
     }
 }

--- a/test/NuGet.Server.Tests/packages.config
+++ b/test/NuGet.Server.Tests/packages.config
@@ -11,4 +11,5 @@
   <package id="xunit.core" version="2.1.0" targetFramework="net46" />
   <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net46" />
   <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net46" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
While investigating https://github.com/NuGet/NuGetGallery/issues/3277, I found these issue. This PR does not address the underlying issue in https://github.com/NuGet/NuGetGallery/issues/3277, as far as I know.

1. Use the `ServerPackage.Created` for `ODataPackage.Published` (which is based off of file creation time). We are already using `ServerPackage.LastUpdated` (based off of file modification time).
1. Make `Id` and `Version` required for JSON deserialization from the cache file.
1. Catch `JsonSerializationException` when reading the cache file. This can occur when a JSON array has no closing character (`]`). This case indicates a corrupted cache file.
1. Add .sha512 and .nuspec files under the drop directory to the .gitignore.

/cc @emgarten @maartenba 
