### PR TITLE
Make the controller and repository stack async

### DIFF
--- a/src/NuGet.Server.Core/Infrastructure/IServerPackageRepository.cs
+++ b/src/NuGet.Server.Core/Infrastructure/IServerPackageRepository.cs
@@ -2,7 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace NuGet.Server.Core.Infrastructure
 {
@@ -10,17 +11,18 @@ namespace NuGet.Server.Core.Infrastructure
     {
         string Source { get; }
 
-        void AddPackage(IPackage package);
+        Task AddPackageAsync(IPackage package, CancellationToken token);
 
-        IQueryable<IServerPackage> GetPackages();
+        Task<IEnumerable<IServerPackage>> GetPackagesAsync(CancellationToken token);
 
-        IQueryable<IServerPackage> Search(
+        Task<IEnumerable<IServerPackage>> SearchAsync(
             string searchTerm,
             IEnumerable<string> targetFrameworks,
-            bool allowPrereleaseVersions);
+            bool allowPrereleaseVersions,
+            CancellationToken token);
 
-        void ClearCache();
+        Task ClearCacheAsync(CancellationToken token);
 
-        void RemovePackage(string packageId, SemanticVersion version);
+        Task RemovePackageAsync(string packageId, SemanticVersion version, CancellationToken token);
     }
 }

--- a/src/NuGet.Server.Core/Infrastructure/IServerPackageStore.cs
+++ b/src/NuGet.Server.Core/Infrastructure/IServerPackageStore.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace NuGet.Server.Core.Infrastructure
 {
@@ -16,7 +18,7 @@ namespace NuGet.Server.Core.Infrastructure
 
         bool Exists(string id, SemanticVersion version);
 
-        HashSet<ServerPackage> GetAll(bool enableDelisting);
+        Task<HashSet<ServerPackage>> GetAllAsync(bool enableDelisting, CancellationToken token);
 
         void Remove(string id, SemanticVersion version, bool enableDelisting);
     }

--- a/src/NuGet.Server.Core/Infrastructure/ServerPackageExtensions.cs
+++ b/src/NuGet.Server.Core/Infrastructure/ServerPackageExtensions.cs
@@ -14,7 +14,7 @@ namespace NuGet.Server.Core.Infrastructure
             return string.IsNullOrEmpty(package.Version.SpecialVersion);
         }
 
-        public static IQueryable<T> FilterByPrerelease<T>(this IQueryable<T> packages, bool allowPrerelease)
+        public static IEnumerable<T> FilterByPrerelease<T>(this IEnumerable<T> packages, bool allowPrerelease)
             where T : IServerPackage
         {
             if (packages == null)
@@ -30,7 +30,7 @@ namespace NuGet.Server.Core.Infrastructure
             return packages;
         }
         
-        public static IQueryable<T> Find<T>(this IQueryable<T> packages, string searchText)
+        public static IEnumerable<T> Find<T>(this IEnumerable<T> packages, string searchText)
             where T : IServerPackage
         {
             var terms = searchText

--- a/src/NuGet.Server.Core/Infrastructure/ServerPackageRepository.cs
+++ b/src/NuGet.Server.Core/Infrastructure/ServerPackageRepository.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using NuGet.Server.Core.Logging;
 
 namespace NuGet.Server.Core.Infrastructure
@@ -20,7 +21,7 @@ namespace NuGet.Server.Core.Infrastructure
     public class ServerPackageRepository
         : IServerPackageRepository, IDisposable
     {
-        private readonly object _syncLock = new object();
+        private readonly SemaphoreSlim _syncLock = new SemaphoreSlim(1);
 
         private readonly IFileSystem _fileSystem;
         private readonly IServerPackageStore _serverPackageStore;
@@ -118,7 +119,7 @@ namespace NuGet.Server.Core.Infrastructure
         /// Package cache containing packages metadata. 
         /// This data is generated if it does not exist already.
         /// </summary>
-        public IQueryable<IServerPackage> GetPackages()
+        public async Task<IEnumerable<IServerPackage>> GetPackagesAsync(CancellationToken token)
         {
 		    /*
              * We rebuild the package storage under either of two conditions:
@@ -132,11 +133,11 @@ namespace NuGet.Server.Core.Infrastructure
              */
             if (_needsRebuild || _serverPackageCache.IsEmpty())
             {
-                lock (_syncLock)
+                using (await LockAndSuppressFileSystemWatcherAsync(token))
                 {
                     if (_needsRebuild || _serverPackageCache.IsEmpty())
                     {
-                        RebuildPackageStore();
+                        await RebuildPackageStoreWithoutLockingAsync(token);
                     }
                 }
             }
@@ -157,14 +158,16 @@ namespace NuGet.Server.Core.Infrastructure
             }
 
             // Return packages
-            return _serverPackageCache
-                .GetAll()
-                .AsQueryable();
+            return _serverPackageCache.GetAll();
         }
 
-        public IQueryable<IServerPackage> Search(string searchTerm, IEnumerable<string> targetFrameworks, bool allowPrereleaseVersions)
+        public async Task<IEnumerable<IServerPackage>> SearchAsync(
+            string searchTerm,
+            IEnumerable<string> targetFrameworks,
+            bool allowPrereleaseVersions,
+            CancellationToken token)
         {
-            var cache = GetPackages();
+            var cache = await GetPackagesAsync(token);
 
             var packages = cache
                 .Find(searchTerm)
@@ -190,74 +193,82 @@ namespace NuGet.Server.Core.Infrastructure
             return packages;
         }
 
-        private void AddPackagesFromDropFolder()
+        private async Task AddPackagesFromDropFolderAsync(CancellationToken token)
+        {
+            using (await LockAndSuppressFileSystemWatcherAsync(token))
+            {
+                await AddPackagesFromDropFolderWithoutLockingAsync(token);
+            }
+        }
+
+        /// <summary>
+        /// This method requires <see cref="LockAndSuppressFileSystemWatcherAsync(CancellationToken)"/>.
+        /// </summary>
+        private async Task AddPackagesFromDropFolderWithoutLockingAsync(CancellationToken token)
         {
             _logger.Log(LogLevel.Info, "Start adding packages from drop folder.");
 
-            using (LockAndSuppressFileSystemWatcher())
+            try
             {
-                try
-                {
-                    var serverPackages = new HashSet<ServerPackage>(IdAndVersionEqualityComparer.Instance);
+                var serverPackages = new HashSet<ServerPackage>(IdAndVersionEqualityComparer.Instance);
 
-                    foreach (var packageFile in _fileSystem.GetFiles(_fileSystem.Root, "*.nupkg", false))
+                foreach (var packageFile in _fileSystem.GetFiles(_fileSystem.Root, "*.nupkg", false))
+                {
+                    try
                     {
-                        try
+                        // Create package
+                        var package = new OptimizedZipPackage(_fileSystem, packageFile);
+
+                        if (!await CanPackageBeAddedAsync(package, shouldThrow: false, token: token))
                         {
-                            // Create package
-                            var package = new OptimizedZipPackage(_fileSystem, packageFile);
-
-                            if (!CanPackageBeAdded(package, shouldThrow: false))
-                            {
-                                continue;
-                            }
-
-                            // Add the package to the file system store.
-                            var serverPackage = _serverPackageStore.Add(
-                                package,
-                                EnableDelisting);
-
-                            // Keep track of the the package for addition to metadata store.
-                            serverPackages.Add(serverPackage);
-
-                            // Remove file from drop folder
-                            _fileSystem.DeleteFile(packageFile);
+                            continue;
                         }
-                        catch (UnauthorizedAccessException ex)
-                        {
-                            // The file may be in use (still being copied) - ignore the error
-                            _logger.Log(LogLevel.Error, "Error adding package file {0} from drop folder: {1}", packageFile, ex.Message);
-                        }
-                        catch (IOException ex)
-                        {
-                            // The file may be in use (still being copied) - ignore the error
-                            _logger.Log(LogLevel.Error, "Error adding package file {0} from drop folder: {1}", packageFile, ex.Message);
-                        }
+
+                        // Add the package to the file system store.
+                        var serverPackage = _serverPackageStore.Add(
+                            package,
+                            EnableDelisting);
+
+                        // Keep track of the the package for addition to metadata store.
+                        serverPackages.Add(serverPackage);
+
+                        // Remove file from drop folder
+                        _fileSystem.DeleteFile(packageFile);
                     }
-
-                    // Add packages to metadata store in bulk
-                    _serverPackageCache.AddRange(serverPackages);
-                    _serverPackageCache.PersistIfDirty();
-
-                    _logger.Log(LogLevel.Info, "Finished adding packages from drop folder.");
+                    catch (UnauthorizedAccessException ex)
+                    {
+                        // The file may be in use (still being copied) - ignore the error
+                        _logger.Log(LogLevel.Error, "Error adding package file {0} from drop folder: {1}", packageFile, ex.Message);
+                    }
+                    catch (IOException ex)
+                    {
+                        // The file may be in use (still being copied) - ignore the error
+                        _logger.Log(LogLevel.Error, "Error adding package file {0} from drop folder: {1}", packageFile, ex.Message);
+                    }
                 }
-                finally
-                {
-                    OptimizedZipPackage.PurgeCache();
-                }
+
+                // Add packages to metadata store in bulk
+                _serverPackageCache.AddRange(serverPackages);
+                _serverPackageCache.PersistIfDirty();
+
+                _logger.Log(LogLevel.Info, "Finished adding packages from drop folder.");
+            }
+            finally
+            {
+                OptimizedZipPackage.PurgeCache();
             }
         }
 
         /// <summary>
         /// Add a file to the repository.
         /// </summary>
-        public void AddPackage(IPackage package)
+        public async Task AddPackageAsync(IPackage package, CancellationToken token)
         {
             _logger.Log(LogLevel.Info, "Start adding package {0} {1}.", package.Id, package.Version);
 
-            CanPackageBeAdded(package, shouldThrow: true);
+            await CanPackageBeAddedAsync(package, shouldThrow: true, token: token);
 
-            using (LockAndSuppressFileSystemWatcher())
+            using (await LockAndSuppressFileSystemWatcherAsync(token))
             {
                 // Add the package to the file system store.
                 var serverPackage = _serverPackageStore.Add(
@@ -271,7 +282,7 @@ namespace NuGet.Server.Core.Infrastructure
             }
         }
 
-        private bool CanPackageBeAdded(IPackage package, bool shouldThrow)
+        private async Task<bool> CanPackageBeAddedAsync(IPackage package, bool shouldThrow, CancellationToken token)
         {
             if (IgnoreSymbolsPackages && package.IsSymbolsPackage())
             {
@@ -288,7 +299,7 @@ namespace NuGet.Server.Core.Infrastructure
             }
 
             // Does the package already exist?
-            if (!AllowOverrideExistingPackageOnPush && this.FindPackage(package.Id, package.Version) != null)
+            if (!AllowOverrideExistingPackageOnPush && await this.FindPackageAsync(package.Id, package.Version, token) != null)
             {
                 var message = string.Format(Strings.Error_PackageAlreadyExists, package);
 
@@ -308,11 +319,11 @@ namespace NuGet.Server.Core.Infrastructure
         /// <summary>
         /// Remove a package from the repository.
         /// </summary>
-        public void RemovePackage(string id, SemanticVersion version)
+        public async Task RemovePackageAsync(string id, SemanticVersion version, CancellationToken token)
         {
             _logger.Log(LogLevel.Info, "Start removing package {0} {1}.", id, version);
 
-            var package = this.FindPackage(id, version);
+            var package = await this.FindPackageAsync(id, version, token);
 
             if (package == null)
             {
@@ -320,7 +331,7 @@ namespace NuGet.Server.Core.Infrastructure
                 return;
             }
 
-            using (LockAndSuppressFileSystemWatcher())
+            using (await LockAndSuppressFileSystemWatcherAsync(token))
             {
                 // Update the file system.
                 _serverPackageStore.Remove(package.Id, package.Version, EnableDelisting);
@@ -362,61 +373,73 @@ namespace NuGet.Server.Core.Infrastructure
             _serverPackageCache.PersistIfDirty();
         }
 
-        private void RebuildPackageStore()
+        private async void RebuildPackageStoreAsync(CancellationToken token)
         {
-            lock (_syncLock)
+            using (await LockAndSuppressFileSystemWatcherAsync(token))
             {
-                _logger.Log(LogLevel.Info, "Start rebuilding package store...");
-
-                // Build cache
-                var packages = ReadPackagesFromDisk();
-                _serverPackageCache.Clear();
-                _serverPackageCache.AddRange(packages);
-
-                // Add packages from drop folder
-                AddPackagesFromDropFolder();
-
-                // Persist
-                _serverPackageCache.PersistIfDirty();
-
-                _needsRebuild = false;
-
-                _logger.Log(LogLevel.Info, "Finished rebuilding package store.");
+                await RebuildPackageStoreWithoutLockingAsync(token);
             }
         }
 
         /// <summary>
-        /// ReadPackagesFromDisk loads all packages from disk and determines additional metadata such as the hash, IsAbsoluteLatestVersion, and IsLatestVersion.
+        /// This method requires <see cref="LockAndSuppressFileSystemWatcherAsync(CancellationToken)"/>.
         /// </summary>
-        private HashSet<ServerPackage> ReadPackagesFromDisk()
+        private async Task RebuildPackageStoreWithoutLockingAsync(CancellationToken token)
+        {
+            _logger.Log(LogLevel.Info, "Start rebuilding package store...");
+
+            // Build cache
+            var packages = await ReadPackagesFromDiskWithoutLockingAsync(token);
+            _serverPackageCache.Clear();
+            _serverPackageCache.AddRange(packages);
+
+            // Add packages from drop folder
+            await AddPackagesFromDropFolderWithoutLockingAsync(token);
+
+            // Persist
+            _serverPackageCache.PersistIfDirty();
+
+            _needsRebuild = false;
+
+            _logger.Log(LogLevel.Info, "Finished rebuilding package store.");
+        }
+
+        /// <summary>
+        /// ReadPackagesFromDisk loads all packages from disk and determines additional metadata such as the hash,
+        /// IsAbsoluteLatestVersion, and IsLatestVersion.
+        /// 
+        /// This method requires <see cref="LockAndSuppressFileSystemWatcherAsync(CancellationToken)"/>.
+        /// </summary>
+        private async Task<HashSet<ServerPackage>> ReadPackagesFromDiskWithoutLockingAsync(CancellationToken token)
         {
             _logger.Log(LogLevel.Info, "Start reading packages from disk...");
 
-            using (LockAndSuppressFileSystemWatcher())
+            try
             {
-                try
-                {
-                    var packages = _serverPackageStore.GetAll(EnableDelisting);
+                var packages = await _serverPackageStore.GetAllAsync(EnableDelisting, token);
 
-                    _logger.Log(LogLevel.Info, "Finished reading packages from disk.");
-;
-                    return packages;
-                }
-                catch (Exception ex)
-                {
-                    _logger.Log(LogLevel.Error, "Error while reading packages from disk: {0} {1}", ex.Message, ex.StackTrace);
+                _logger.Log(LogLevel.Info, "Finished reading packages from disk.");
+                ;
+                return packages;
+            }
+            catch (Exception ex)
+            {
+                _logger.Log(
+                    LogLevel.Error,
+                    "Error while reading packages from disk: {0} {1}",
+                    ex.Message,
+                    ex.StackTrace);
 
-                    throw;
-                }
+                throw;
             }
         }
         
         /// <summary>
         /// Sets the current cache to null so it will be regenerated next time.
         /// </summary>
-        public void ClearCache()
+        public async Task ClearCacheAsync(CancellationToken token)
         {
-            using (LockAndSuppressFileSystemWatcher())
+            using (await LockAndSuppressFileSystemWatcherAsync(token))
             {
                 OptimizedZipPackage.PurgeCache();
 
@@ -432,12 +455,18 @@ namespace NuGet.Server.Core.Infrastructure
             _logger.Log(LogLevel.Info, "Registering background jobs...");
 
             // Persist to package store at given interval (when dirty)
-            _persistenceTimer = new Timer(state =>
-                _serverPackageCache.PersistIfDirty(), null, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
+            _persistenceTimer = new Timer(
+                callback: state => _serverPackageCache.PersistIfDirty(),
+                state: null,
+                dueTime: TimeSpan.FromMinutes(1),
+                period: TimeSpan.FromMinutes(1));
 
             // Rebuild the package store in the background (every hour)
-            _rebuildTimer = new Timer(state =>
-                RebuildPackageStore(), null, TimeSpan.FromSeconds(15), TimeSpan.FromHours(1));
+            _rebuildTimer = new Timer(
+                callback: state => RebuildPackageStoreAsync(CancellationToken.None),
+                state: null,
+                dueTime: TimeSpan.FromSeconds(15),
+                period: TimeSpan.FromHours(1));
 
             _logger.Log(LogLevel.Info, "Finished registering background jobs.");
         }
@@ -455,10 +484,10 @@ namespace NuGet.Server.Core.Infrastructure
                 _fileSystemWatcher.Filter = "*";
                 _fileSystemWatcher.IncludeSubdirectories = true;
 
-                _fileSystemWatcher.Changed += FileSystemChanged;
-                _fileSystemWatcher.Created += FileSystemChanged;
-                _fileSystemWatcher.Deleted += FileSystemChanged;
-                _fileSystemWatcher.Renamed += FileSystemChanged;
+                _fileSystemWatcher.Changed += FileSystemChangedAsync;
+                _fileSystemWatcher.Created += FileSystemChangedAsync;
+                _fileSystemWatcher.Deleted += FileSystemChangedAsync;
+                _fileSystemWatcher.Renamed += FileSystemChangedAsync;
 
                 _fileSystemWatcher.EnableRaisingEvents = true;
 
@@ -474,10 +503,10 @@ namespace NuGet.Server.Core.Infrastructure
             if (_fileSystemWatcher != null)
             {
                 _fileSystemWatcher.EnableRaisingEvents = false;
-                _fileSystemWatcher.Changed -= FileSystemChanged;
-                _fileSystemWatcher.Created -= FileSystemChanged;
-                _fileSystemWatcher.Deleted -= FileSystemChanged;
-                _fileSystemWatcher.Renamed -= FileSystemChanged;
+                _fileSystemWatcher.Changed -= FileSystemChangedAsync;
+                _fileSystemWatcher.Created -= FileSystemChangedAsync;
+                _fileSystemWatcher.Deleted -= FileSystemChangedAsync;
+                _fileSystemWatcher.Renamed -= FileSystemChangedAsync;
                 _fileSystemWatcher.Dispose();
                 _fileSystemWatcher = null;
 
@@ -485,7 +514,7 @@ namespace NuGet.Server.Core.Infrastructure
             }
         }
 
-        private void FileSystemChanged(object sender, FileSystemEventArgs e)
+        private async void FileSystemChangedAsync(object sender, FileSystemEventArgs e)
         {
             if (_isFileSystemWatcherSuppressed)
             {
@@ -499,7 +528,7 @@ namespace NuGet.Server.Core.Infrastructure
                 && string.Equals(Path.GetExtension(e.Name), ".nupkg", StringComparison.OrdinalIgnoreCase))
             {
                 // When a package is dropped into the server packages root folder, add it to the repository.
-                AddPackagesFromDropFolder();
+                await AddPackagesFromDropFolderAsync(CancellationToken.None);
             }
 
             // 2) If a file is updated in a subdirectory, *or* a folder is deleted, invalidate the cache
@@ -509,18 +538,56 @@ namespace NuGet.Server.Core.Infrastructure
                 // TODO: invalidating *all* packages for every nupkg change under this folder seems more expensive than it should.
                 // Recommend using e.FullPath to figure out which nupkgs need to be (re)computed.
 
-                ClearCache();
+                await ClearCacheAsync(CancellationToken.None);
             }
         }
-        
-        private IDisposable LockAndSuppressFileSystemWatcher()
+
+        private async Task<DisposableSemphoreSlim> LockAsync(CancellationToken token)
         {
-            return new SupressedFileSystemWatcher(this);
+            var handle = new DisposableSemphoreSlim(_syncLock);
+            await handle.WaitAsync(token);
+            return handle;
+        }
+
+        private async Task<SupressedFileSystemWatcher> LockAndSuppressFileSystemWatcherAsync(CancellationToken token)
+        {
+            var handle = new SupressedFileSystemWatcher(this);
+            await handle.WaitAsync(token);
+            return handle;
+        }
+
+        private class DisposableSemphoreSlim : IDisposable
+        {
+            private readonly SemaphoreSlim _semaphore;
+            private bool _lockTaken;
+
+            public DisposableSemphoreSlim(SemaphoreSlim semaphore)
+            {
+                _semaphore = semaphore;
+            }
+
+            public bool LockTaken => _lockTaken;
+
+            public async Task WaitAsync(CancellationToken token)
+            {
+                await _semaphore.WaitAsync(token);
+                _lockTaken = true;
+            }
+
+            public void Dispose()
+            {
+                if (_lockTaken)
+                {
+                    _semaphore.Release();
+                    _lockTaken = false;
+                }
+            }
         }
 
         private class SupressedFileSystemWatcher : IDisposable
         {
             private readonly ServerPackageRepository _repository;
+            private DisposableSemphoreSlim _lockHandle;
 
             public SupressedFileSystemWatcher(ServerPackageRepository repository)
             {
@@ -530,32 +597,23 @@ namespace NuGet.Server.Core.Infrastructure
                 }
 
                 _repository = repository;
+            }
 
-                // Lock the repository.
-                bool lockTaken = false;
-                try
-                {
-                    Monitor.Enter(_repository._syncLock, ref lockTaken);
-                }
-                catch
-                {
-                    if (lockTaken)
-                    {
-                        Monitor.Exit(_repository._syncLock);
-                    }
+            public bool LockTaken => _lockHandle.LockTaken;
 
-                    throw;
-                }
-
-                // Suppress the file system events.
+            public async Task WaitAsync(CancellationToken token)
+            {
+                _lockHandle = await _repository.LockAsync(token);
                 _repository._isFileSystemWatcherSuppressed = true;
             }
 
             public void Dispose()
             {
-                Monitor.Exit(_repository._syncLock);
-
-                _repository._isFileSystemWatcherSuppressed = false;
+                if (_lockHandle != null && _lockHandle.LockTaken)
+                {
+                    _lockHandle.Dispose();
+                    _repository._isFileSystemWatcherSuppressed = false;
+                }
             }
         }
     }

--- a/src/NuGet.Server.Core/Infrastructure/ServerPackageStore.cs
+++ b/src/NuGet.Server.Core/Infrastructure/ServerPackageStore.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Server.Core.Logging;
 
@@ -77,37 +78,49 @@ namespace NuGet.Server.Core.Infrastructure
             }
         }
 
-        public HashSet<ServerPackage> GetAll(bool enableDelisting)
+        public async Task<HashSet<ServerPackage>> GetAllAsync(bool enableDelisting, CancellationToken token)
         {
             var allPackages = new ConcurrentBag<ServerPackage>();
-            
-            Parallel.ForEach(_repository.GetPackages(), package =>
-            {
-                ServerPackage serverPackage;
 
-                // Try to create the server package and ignore a bad package if it fails.
-                if (TryCreateServerPackage(package, enableDelisting, out serverPackage))
-                {
-                    allPackages.Add(serverPackage);
-                }
-            });
+            var tasks = _repository
+                .GetPackages()
+                .Select(package => TryAddServerPackageAsync(allPackages, package, enableDelisting, token))
+                .ToList();
+
+            await Task.WhenAll(tasks);
 
             // Only return unique packages.
             return new HashSet<ServerPackage>(allPackages, IdAndVersionEqualityComparer.Instance);
         }
 
-        private bool TryCreateServerPackage(IPackage package, bool enableDelisting, out ServerPackage serverPackage)
+        private async Task TryAddServerPackageAsync(
+            ConcurrentBag<ServerPackage> allPackages,
+            IPackage package,
+            bool enableDelisting,
+            CancellationToken token)
+        {
+            // Immediatelly defer work to the background thread.
+            await Task.Yield();
+
+            // Try to create the server package and ignore a bad package if it fails.
+            var serverPackage = await CreateServerPackageAsync(package, enableDelisting, token);
+            if (serverPackage != null)
+            {
+                allPackages.Add(serverPackage);
+            }
+        }
+
+        private Task<ServerPackage> CreateServerPackageAsync(
+            IPackage package,
+            bool enableDelisting,
+            CancellationToken token)
         {
             try
             {
-                serverPackage = CreateServerPackage(package, enableDelisting);
-
-                return true;
+                return Task.FromResult(CreateServerPackage(package, enableDelisting));
             }
             catch (Exception e)
             {
-                serverPackage = null;
-
                 _logger.Log(
                     LogLevel.Warning,
                     "Unable to create server package - {0} {1}: {2}",
@@ -115,7 +128,7 @@ namespace NuGet.Server.Core.Infrastructure
                     package.Version,
                     e.Message);
 
-                return false;
+                return null;
             }
         }
 

--- a/src/NuGet.Server.Core/Infrastructure/ServerPackageStore.cs
+++ b/src/NuGet.Server.Core/Infrastructure/ServerPackageStore.cs
@@ -99,25 +99,25 @@ namespace NuGet.Server.Core.Infrastructure
             bool enableDelisting,
             CancellationToken token)
         {
-            // Immediatelly defer work to the background thread.
+            // Immediately defer work to the background thread.
             await Task.Yield();
 
             // Try to create the server package and ignore a bad package if it fails.
-            var serverPackage = await CreateServerPackageAsync(package, enableDelisting, token);
+            var serverPackage = CreateServerPackage(package, enableDelisting, token);
             if (serverPackage != null)
             {
                 allPackages.Add(serverPackage);
             }
         }
 
-        private Task<ServerPackage> CreateServerPackageAsync(
+        private ServerPackage CreateServerPackage(
             IPackage package,
             bool enableDelisting,
             CancellationToken token)
         {
             try
             {
-                return Task.FromResult(CreateServerPackage(package, enableDelisting));
+                return CreateServerPackage(package, enableDelisting);
             }
             catch (Exception e)
             {

--- a/src/NuGet.Server/Controllers/PackagesODataController.cs
+++ b/src/NuGet.Server/Controllers/PackagesODataController.cs
@@ -3,6 +3,8 @@
 
 using System.Net;
 using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Web.Http;
 using NuGet.Server.Core.Infrastructure;
 using NuGet.Server.V2.Controllers;
@@ -39,11 +41,11 @@ namespace NuGet.Server.DataServices
 
         [HttpGet]
         // Exposed through ordinary Web API route. Bypasses OData pipeline.
-        public HttpResponseMessage ClearCache()
+        public async Task<HttpResponseMessage> ClearCache(CancellationToken token)
         {
             if (RequestContext.IsLocal)
             {
-                _serverRepository.ClearCache();
+                await _serverRepository.ClearCacheAsync(token);
                 return CreateStringResponse(HttpStatusCode.OK, "Server cache has been cleared.");
             }
             else

--- a/test/NuGet.Server.V2.Tests/Infrastructure/ControllerTestHelpers.cs
+++ b/test/NuGet.Server.V2.Tests/Infrastructure/ControllerTestHelpers.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
 using System.Linq;
+using System.Threading;
 using Moq;
 using NuGet.Server.Core.Infrastructure;
 
@@ -15,7 +16,7 @@ namespace NuGet.Server.V2.Tests.Infrastructure
             //var bazPackage = new PackageRegistration { Id = "Baz" };
 
             var repo = new Mock<IServerPackageRepository>(MockBehavior.Strict);
-            repo.Setup(r => r.GetPackages()).Returns(new[]
+            repo.Setup(r => r.GetPackagesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new[]
             {
                 new ServerPackage
                 {


### PR DESCRIPTION
To facilitate async IO operations at the bottom of the stack, I have changed `IServerPackageRepository`, `IServerPackageStore`, and `NuGetODataController` to be async.

This will ease future improvements such as switching from NuGet.Core (sync APIs) to NuGet 3.x/4.x (a lot of async APIs).

/cc @dtivel @emgarten @maartenba 