### PR TITLE
Fix deadlock when reading packages from the drop folder

### DIFF
--- a/src/NuGet.Server.Core/Infrastructure/IServerPackageCache.cs
+++ b/src/NuGet.Server.Core/Infrastructure/IServerPackageCache.cs
@@ -14,6 +14,8 @@ namespace NuGet.Server.Core.Infrastructure
     {
         bool IsEmpty();
 
+        bool Exists(string id, SemanticVersion version);
+
         IEnumerable<ServerPackage> GetAll();
 
         void Add(ServerPackage entity);

--- a/src/NuGet.Server.Core/Infrastructure/ServerPackageCache.cs
+++ b/src/NuGet.Server.Core/Infrastructure/ServerPackageCache.cs
@@ -87,6 +87,19 @@ namespace NuGet.Server.Core.Infrastructure
             }
         }
 
+        public bool Exists(string id, SemanticVersion version)
+        {
+            _syncLock.EnterReadLock();
+            try
+            {
+                return _packages.Any(p => IsMatch(p, id, version));
+            }
+            finally
+            {
+                _syncLock.ExitReadLock();
+            }
+        }
+
         public IEnumerable<ServerPackage> GetAll()
         {
             _syncLock.EnterReadLock();

--- a/test/NuGet.Server.Core.Tests/ServerPackageCacheTest.cs
+++ b/test/NuGet.Server.Core.Tests/ServerPackageCacheTest.cs
@@ -197,5 +197,59 @@ namespace NuGet.Server.Core.Tests
             Assert.Equal(PackageId, package.Id);
             Assert.Equal(PackageVersion, package.Version);
         }
+
+        [Fact]
+        public void Exists_IsCaseInsensitive()
+        {
+            // Arrange
+            var fileSystem = new Mock<IFileSystem>();
+            fileSystem
+                .Setup(x => x.FileExists(CacheFileName))
+                .Returns(false);
+            var target = new ServerPackageCache(fileSystem.Object, CacheFileName);
+            target.Add(new ServerPackage { Id = "NuGet.Versioning", Version = new SemanticVersion("3.5.0-beta2") });
+
+            // Act
+            var actual = target.Exists("nuget.versioning", new SemanticVersion("3.5.0-BETA2"));
+
+            // Assert
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Exists_ReturnsFalseWhenPackageDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new Mock<IFileSystem>();
+            fileSystem
+                .Setup(x => x.FileExists(CacheFileName))
+                .Returns(false);
+            var target = new ServerPackageCache(fileSystem.Object, CacheFileName);
+            target.Add(new ServerPackage { Id = "NuGet.Versioning", Version = new SemanticVersion("3.5.0-beta2") });
+
+            // Act
+            var actual = target.Exists("NuGet.Frameworks", new SemanticVersion("3.5.0-beta2"));
+
+            // Assert
+            Assert.False(actual);
+        }
+
+        [Fact]
+        public void Exists_ReturnsTrueWhenPackageExists()
+        {
+            // Arrange
+            var fileSystem = new Mock<IFileSystem>();
+            fileSystem
+                .Setup(x => x.FileExists(CacheFileName))
+                .Returns(false);
+            var target = new ServerPackageCache(fileSystem.Object, CacheFileName);
+            target.Add(new ServerPackage { Id = "NuGet.Versioning", Version = new SemanticVersion("3.5.0-beta2") });
+
+            // Act
+            var actual = target.Exists("NuGet.Versioning", new SemanticVersion("3.5.0-beta2"));
+
+            // Assert
+            Assert.True(actual);
+        }
     }
 }


### PR DESCRIPTION
This was a bug introduced by my move to `async` (PR https://github.com/NuGet/NuGet.Server/pull/28).

- Fix deadlock when reading packages from the drop folder.
- Fix potential race condition when two of the same packages are added at the same time.
- Make `allowOverrideExistingPackageOnPush` default to false in repository. It is already defaults to false in the configuration.
- Added tests to validate these changes.

/cc @dtivel
