### PR TITLE
Patch 1

### DIFF
--- a/src/NuGet.Server/Web.config
+++ b/src/NuGet.Server/Web.config
@@ -15,6 +15,7 @@
     -->
     <add key="apiKey" value=""/>
     <!--
+
     Change the path to the packages folder. Default is ~/Packages.
     This can be a virtual or physical path.
     -->
@@ -22,35 +23,36 @@
     <!--
     Set allowOverrideExistingPackageOnPush to false to mimic NuGet.org's behaviour (do not allow overwriting packages with same id + version).
     -->
+
     <add key="allowOverrideExistingPackageOnPush" value="false"/>
     <!--
-    Set ignoreSymbolsPackages to true to filter out symbols packages. Since NuGet.Server does not come with a symbol server,
+>    Set ignoreSymbolsPackages to true to filter out symbols packages. Since NuGet.Server does not come with a symbol server,
     it makes sense to ignore this type of packages. When enabled, files named `.symbols.nupkg` or packages containing a `/src` folder will be ignored.
     
     If you only push .symbols.nupkg packages, set this to false so that packages can be uploaded.
     -->
     <add key="ignoreSymbolsPackages" value="true"/>
-    <!--
+-    <!--
     Set enableDelisting to true to enable delist instead of delete as a result of a "nuget delete" command.
     - delete: package is deleted from the repository's local filesystem.
     - delist: 
-      - "nuget delete": the "hidden" file attribute of the corresponding nupkg on the repository local filesystem is turned on instead of deleting the file.
+-      - "nuget delete": the "hidden" file attribute of the corresponding nupkg on the repository local filesystem is turned on instead of deleting the file.
       - "nuget list" skips delisted packages, i.e. those that have the hidden attribute set on their nupkg.
       - "nuget install packageid -version version" command will succeed for both listed and delisted packages.
         e.g. delisted packages can still be downloaded by clients that explicitly specify their version.
     -->
     <add key="enableDelisting" value="false"/>
-    <!--
+-    <!--
     Set enableFrameworkFiltering to true to enable filtering packages by their supported frameworks during search.
     -->
     <add key="enableFrameworkFiltering" value="false"/>
-    <!--
+-    <!--
     When running NuGet.Server in a NAT network, ASP.NET may embed the erver's internal IP address in the V2 feed.
     Uncomment the following configuration entry to enable NAT support.
     -->
     <!-- <add key="aspnet:UseHostHeaderForRequestUrl" value="true" /> -->
     <!--
-    Set enableFileSystemMonitoring to true (default) to enable file system monitoring (which will update the package cache appropriately on file system changes).
+!    Set enableFileSystemMonitoring to true (default) to enable file system monitoring (which will update the package cache appropriately on file system changes).
     Set it to false to disable file system monitoring.
     NOTE: Disabling file system monitoring may result in increased storage capacity requirements as package cache may only be purged by a background job running 
     on a fixed 1-hour interval.
@@ -89,5 +91,18 @@
         <requestLimits maxAllowedContentLength="31457280"/>
       </requestFiltering>
     </security>
+    <!--Uncomment rewrite rule if you run into server crash on search when results are more then 1 page  ->
+    <!--<rewrite> 
+      <rules>
+        <rule name="append to search queries an optional argument to prevent crash" stopProcessing="true">
+          <match url="(.*)/search()(.*)" />
+	 	  <action type="Redirect" url="{R:0}?includeDelisted=false" redirectType="Found"  />
+          <conditions>
+				<add input="{QUERY_STRING}" pattern="includeDelisted=false" negate="true" />
+             	<add input="{QUERY_STRING}" pattern="includeDelisted=true"  negate="true" />
+		  </conditions>
+		</rule>
+      </rules>
+    </rewrite> -->
   </system.webServer>
 </configuration>


### PR DESCRIPTION
This is a work around for issue NuGet.Server throws exception when paging an endpoint with default query parameters #3578 found here: https://github.com/NuGet/NuGetGallery/issues/3578

You can add this section to the web.config so they have a work around until the issue is fixed in the odata dependencies. You do need to install the iis rewrite module on your iis server for this to work.