### PR TITLE
Include auto-generated assembly metadata

### DIFF
--- a/src/NuGet.Server.Core/NuGet.Server.Core.csproj
+++ b/src/NuGet.Server.Core/NuGet.Server.Core.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Logging\LogLevel.cs" />
     <Compile Include="Logging\TraceLogger.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.*.cs" />
     <Compile Include="Strings.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/NuGet.Server.V2/NuGet.Server.V2.csproj
+++ b/src/NuGet.Server.V2/NuGet.Server.V2.csproj
@@ -101,6 +101,7 @@
     <Compile Include="OData\Serializers\CustomSerializerProvider.cs" />
     <Compile Include="OData\Serializers\NuGetEntityTypeSerializer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.*.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/NuGet.Server/Default.aspx
+++ b/src/NuGet.Server/Default.aspx
@@ -1,6 +1,6 @@
 ﻿<%@ Page Language="C#" %>
 <%@ Import Namespace="NuGet.Server" %>
-<%@ Import Namespace="NuGet.Server.Core.DataServices" %>
+<%@ Import Namespace="NuGet.Server.App_Start" %>
 <%@ Import Namespace="NuGet.Server.Infrastructure" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
@@ -13,7 +13,7 @@
 </head>
 <body>
     <div>
-        <h2>You are running NuGet.Server v<%= typeof(ODataPackage).Assembly.GetName().Version %></h2>
+        <h2>You are running NuGet.Server v<%= typeof(NuGetODataConfig).Assembly.GetName().Version %></h2>
         <p>
             Click <a href="<%= VirtualPathUtility.ToAbsolute("~/nuget/Packages") %>">here</a> to view your packages.
         </p>
@@ -25,13 +25,13 @@
                 <strong><%= Helpers.GetRepositoryUrl(Request.Url, Request.ApplicationPath) %></strong>
             </blockquote>
             <% if (string.IsNullOrEmpty(ConfigurationManager.AppSettings["apiKey"])) { %>
-            To enable pushing packages to this feed using the <a href="https://www.nuget.org/downloads">NuGet command line tool</a> (nuget.exe), set the api key appSetting in web.config.
+            To enable pushing packages to this feed using the <a href="https://www.nuget.org/downloads">NuGet command line tool</a> (nuget.exe), set the <code>apiKey</code> appSetting in web.config.
             <% } else { %>
             Use the command below to push packages to this feed using the <a href="https://www.nuget.org/downloads">NuGet command line tool</a> (nuget.exe).
-            <% } %>
             <blockquote>
                 <strong>nuget.exe push {package file} {apikey} -Source <%= Helpers.GetPushUrl(Request.Url, Request.ApplicationPath) %></strong>
-            </blockquote>            
+            </blockquote>
+            <% } %> 
         </fieldset>
 
         <% if (Request.IsLocal) { %>


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/3656.

1. Include auto-generated assembly info file
1. Use a NuGet.Server.dll type for front page version
1. Don't show the example push command if the API key has not been configured

