### PR TITLE
SemVer 2.0.0 version ranges imply that the package itself is SemVer 2.0.0

### DIFF
--- a/src/NuGet.Server.Core/Infrastructure/JsonNetPackagesSerializer.cs
+++ b/src/NuGet.Server.Core/Infrastructure/JsonNetPackagesSerializer.cs
@@ -13,7 +13,7 @@ namespace NuGet.Server.Core.Infrastructure
     public class JsonNetPackagesSerializer
         : IPackagesSerializer
     {
-        private static readonly SemanticVersion CurrentSchemaVersion = new SemanticVersion("2.0.0");
+        private static readonly SemanticVersion CurrentSchemaVersion = new SemanticVersion("3.0.0");
 
         private readonly JsonSerializer _serializer = new JsonSerializer
         {

--- a/src/NuGet.Server.Core/Infrastructure/ServerPackageCache.cs
+++ b/src/NuGet.Server.Core/Infrastructure/ServerPackageCache.cs
@@ -196,7 +196,7 @@ namespace NuGet.Server.Core.Infrastructure
                 package.SemVer2IsLatest = false;
 
                 // Update the SemVer1 views.
-                if (!package.Version.IsSemVer2())
+                if (!package.IsSemVer2)
                 {
                     UpdateLatestDictionary(semVer1AbsoluteLatest, package);
 

--- a/src/NuGet.Server.Core/Infrastructure/ServerPackageRepository.cs
+++ b/src/NuGet.Server.Core/Infrastructure/ServerPackageRepository.cs
@@ -144,7 +144,7 @@ namespace NuGet.Server.Core.Infrastructure
 
             if (!compatibility.AllowSemVer2)
             {
-                cache = cache.Where(p => !p.Version.IsSemVer2());
+                cache = cache.Where(p => !p.IsSemVer2);
             }
 
             return cache;

--- a/test/NuGet.Server.Core.Tests/NuGet.Server.Core.Tests.csproj
+++ b/test/NuGet.Server.Core.Tests/NuGet.Server.Core.Tests.csproj
@@ -95,6 +95,7 @@
     <Compile Include="ServerPackageRepositoryTest.cs" />
     <Compile Include="ServerPackageCacheTest.cs" />
     <Compile Include="ServerPackageStoreTest.cs" />
+    <Compile Include="ServerPackageTest.cs" />
     <Compile Include="TestData.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/NuGet.Server.Core.Tests/ServerPackageRepositoryTest.cs
+++ b/test/NuGet.Server.Core.Tests/ServerPackageRepositoryTest.cs
@@ -419,7 +419,10 @@ namespace NuGet.Server.Core.Tests
                 var actual = await serverRepository.GetPackagesAsync(ClientCompatibility.Default, Token);
 
                 // Assert
-                Assert.Equal(2, actual.Count());
+                var packages = actual.OrderBy(p => p.Id).ToList();
+                Assert.Equal(2, packages.Count);
+                Assert.Equal("test1", packages[0].Id);
+                Assert.Equal("test2", packages[1].Id);
             }
         }
 
@@ -435,7 +438,13 @@ namespace NuGet.Server.Core.Tests
                 var actual = await serverRepository.GetPackagesAsync(ClientCompatibility.Max, Token);
 
                 // Assert
-                Assert.Equal(5, actual.Count());
+                var packages = actual.OrderBy(p => p.Id).ToList();
+                Assert.Equal(5, packages.Count);
+                Assert.Equal("test1", packages[0].Id);
+                Assert.Equal("test2", packages[1].Id);
+                Assert.Equal("test3", packages[2].Id);
+                Assert.Equal("test4", packages[3].Id);
+                Assert.Equal("test5", packages[4].Id);
             }
         }
 

--- a/test/NuGet.Server.Core.Tests/ServerPackageRepositoryTest.cs
+++ b/test/NuGet.Server.Core.Tests/ServerPackageRepositoryTest.cs
@@ -51,6 +51,12 @@ namespace NuGet.Server.Core.Tests
                 repository.AddPackage(CreatePackage("test2", "1.0-beta"));
                 repository.AddPackage(CreatePackage("test3", "1.0-beta.1"));
                 repository.AddPackage(CreatePackage("test4", "1.0-beta+foo"));
+                repository.AddPackage(CreatePackage(
+                    "test5",
+                    "1.0-beta",
+                    new PackageDependency(
+                        "SomePackage",
+                        VersionUtility.ParseVersionSpec("1.0.0-beta.1"))));
             });
         }
 
@@ -429,7 +435,7 @@ namespace NuGet.Server.Core.Tests
                 var actual = await serverRepository.GetPackagesAsync(ClientCompatibility.Max, Token);
 
                 // Assert
-                Assert.Equal(4, actual.Count());
+                Assert.Equal(5, actual.Count());
             }
         }
 
@@ -780,7 +786,7 @@ namespace NuGet.Server.Core.Tests
             return package.Object;
         }
 
-        private IPackage CreatePackage(string id, string version)
+        private IPackage CreatePackage(string id, string version, PackageDependency packageDependency = null)
         {
             var parsedVersion = new SemanticVersion(version);
             var packageBuilder = new PackageBuilder
@@ -790,6 +796,16 @@ namespace NuGet.Server.Core.Tests
                 Description = "Description",
                 Authors = { "Test Author" }
             };
+
+            if (packageDependency != null)
+            {
+                packageBuilder.DependencySets.Add(new PackageDependencySet(
+                    new FrameworkName(".NETFramework,Version=v4.5"),
+                    new[]
+                    {
+                        packageDependency
+                    }));
+            }
 
             var mockFile = new Mock<IPackageFile>();
             mockFile.Setup(m => m.Path).Returns("foo");

--- a/test/NuGet.Server.Core.Tests/ServerPackageTest.cs
+++ b/test/NuGet.Server.Core.Tests/ServerPackageTest.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using System.Linq;
+using System.Runtime.Versioning;
+using Moq;
+using Xunit;
+
+namespace NuGet.Server.Core.Infrastructure.Tests
+{
+    public class ServerPackageTest
+    {
+        [Theory]
+        [InlineData("1.0.0", false)]
+        [InlineData("1.0.0-alpha", false)]
+        [InlineData("1.0.0-alpha.1", true)]
+        [InlineData("1.0.0+githash", true)]
+        [InlineData("1.0.0-alpha+githash", true)]
+        [InlineData("1.0.0-alpha.1+githash", true)]
+        public void IsSemVer2_CanBeDeterminedByPackageVersion(string version, bool isSemVer2)
+        {
+            // Arrange
+            var package = new Mock<IPackage>();
+            package.Setup(x => x.Version).Returns(new SemanticVersion(version));
+            var packageDerivedData = new PackageDerivedData();
+
+            // Act
+            var serverPackage = new ServerPackage(package.Object, packageDerivedData);
+
+            // Assert
+            Assert.Equal(isSemVer2, serverPackage.IsSemVer2);
+        }
+
+        [Theory]
+        [InlineData("1.0.0", false)]
+        [InlineData("1.0.0-alpha", false)]
+        [InlineData("1.0.0-alpha.1", true)]
+        [InlineData("[1.0.0-alpha.1, 2.0.0)", true)]
+        [InlineData("[1.0.0+githash, 2.0.0)", true)]
+        [InlineData("[1.0.0-alpha, 2.0.0-alpha.1)", true)]
+        [InlineData("[1.0.0, 2.0.0+githash)", true)]
+        [InlineData("[1.0.0-alpha, 2.0.0)", false)]
+        public void IsSemVer2_CanBeDeterminedByDependencyVersionRange(string versionRange, bool isSemVer2)
+        {
+            // Arrange
+            var package = new Mock<IPackage>();
+            package
+                .Setup(x => x.Version)
+                .Returns(new SemanticVersion("1.0.0"));
+            package
+                .Setup(x => x.DependencySets)
+                .Returns(new[]
+                {
+                    new PackageDependencySet(
+                        new FrameworkName(".NETFramework,Version=v4.5"),
+                        new[]
+                        {
+                            new PackageDependency("OtherPackage", VersionUtility.ParseVersionSpec(versionRange))
+                        })
+                }.AsEnumerable());
+            var packageDerivedData = new PackageDerivedData();
+
+            // Act
+            var serverPackage = new ServerPackage(package.Object, packageDerivedData);
+
+            // Assert
+            Assert.Equal(isSemVer2, serverPackage.IsSemVer2);
+        }
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/3657.

This is adhering to the latest (internal) SemVer 2.0.0 protocol specification.