### PR TITLE
Change ODataPackage so its Published property is included in output

### DIFF
--- a/src/NuGet.Server/DataServices/ODataPackage.cs
+++ b/src/NuGet.Server/DataServices/ODataPackage.cs
@@ -9,7 +9,7 @@ namespace NuGet.Server.DataServices
     [DataServiceKey("Id", "Version")]
     [EntityPropertyMapping("Id", SyndicationItemProperty.Title, SyndicationTextContentKind.Plaintext, keepInContent: false)]
     [EntityPropertyMapping("Authors", SyndicationItemProperty.AuthorName, SyndicationTextContentKind.Plaintext, keepInContent: false)]
-    [EntityPropertyMapping("Published", SyndicationItemProperty.Published, SyndicationTextContentKind.Plaintext, keepInContent: false)]
+    [EntityPropertyMapping("Published", SyndicationItemProperty.Published, SyndicationTextContentKind.Plaintext, keepInContent: true)]
     [EntityPropertyMapping("LastUpdated", SyndicationItemProperty.Updated, SyndicationTextContentKind.Plaintext, keepInContent: false)]
     [EntityPropertyMapping("Summary", SyndicationItemProperty.Summary, SyndicationTextContentKind.Plaintext, keepInContent: false)]
     [HasStream]


### PR DESCRIPTION
In commit 9a2dd68 an EntityPropertyMapping attribute was added to the ODataPackage class which removed the published date from the OData output, causing Visual Studio to not display a published date for packages.  This changes the EntityPropertyMapping attribute to include the published date in the OData output again so Visual Studio can display a published date for packages.

This would resolve issue NuGet/NuGetGallery#4689.