### PR TITLE
Support projection on the Packages() endpoint ($select)

### DIFF
--- a/src/NuGet.Server.V2/Controllers/NuGetODataController.cs
+++ b/src/NuGet.Server.V2/Controllers/NuGetODataController.cs
@@ -45,10 +45,7 @@ namespace NuGet.Server.V2.Controllers
         }
         
         // GET /Packages
-        // Never seen this invoked. NuGet.Exe and Visual Studio seems to use 'Search' for all package listing.
-        // Probably required to be OData compliant?
         [HttpGet]
-        [EnableQuery(PageSize = 100, HandleNullPropagation = HandleNullPropagationOption.False)]
         public virtual async Task<IHttpActionResult> Get(
             ODataQueryOptions<ODataPackage> options,
             [FromUri] string semVerLevel = "",


### PR DESCRIPTION
Fix https://github.com/NuGet/NuGetGallery/issues/5193

/cc @cmreddyv 

The `EnableQuery` attribute is not needed since the system query parameters (e.g. `$filter`, `$select`) are validated by our `QueryResult` type:
https://github.com/NuGet/NuGet.Server/blob/2972fb387fe65ba03635d5ab76a223e6c38b1a29/src/NuGet.Server.V2/Model/QueryResult.cs#L252-L269