### PR TITLE
Don't extract the entire package to the %TMP% directory

### DIFF
--- a/src/NuGet.Server.Core/Core/NullFileSystem.cs
+++ b/src/NuGet.Server.Core/Core/NullFileSystem.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace NuGet.Server.Core
+{
+    /// <summary>
+    /// A file system implementation that persists nothing. This is intended to be used with
+    /// <see cref="OptimizedZipPackage"/> so that package files are never actually extracted anywhere on disk.
+    /// </summary>
+    public class NullFileSystem : IFileSystem
+    {
+        public static NullFileSystem Instance { get; } = new NullFileSystem();
+
+        public Stream CreateFile(string path) => Stream.Null;
+        public bool DirectoryExists(string path) => true;
+        public bool FileExists(string path) => false;
+        public string GetFullPath(string path) => null;
+        public Stream OpenFile(string path) => Stream.Null;
+
+        public ILogger Logger { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public string Root => throw new NotSupportedException();
+        public void AddFile(string path, Stream stream) => throw new NotSupportedException();
+        public void AddFile(string path, Action<Stream> writeToStream) => throw new NotSupportedException();
+        public void AddFiles(IEnumerable<IPackageFile> files, string rootDir) => throw new NotSupportedException();
+        public void DeleteDirectory(string path, bool recursive) => throw new NotSupportedException();
+        public void DeleteFile(string path) => throw new NotSupportedException();
+        public void DeleteFiles(IEnumerable<IPackageFile> files, string rootDir) => throw new NotSupportedException();
+        public DateTimeOffset GetCreated(string path) => throw new NotSupportedException();
+        public IEnumerable<string> GetDirectories(string path) => throw new NotSupportedException();
+        public IEnumerable<string> GetFiles(string path, string filter, bool recursive) => throw new NotSupportedException();
+        public DateTimeOffset GetLastAccessed(string path) => throw new NotSupportedException();
+        public DateTimeOffset GetLastModified(string path) => throw new NotSupportedException();
+        public void MakeFileWritable(string path) => throw new NotSupportedException();
+        public void MoveFile(string source, string destination) => throw new NotSupportedException();
+    }
+}

--- a/src/NuGet.Server.Core/Core/PackageFactory.cs
+++ b/src/NuGet.Server.Core/Core/PackageFactory.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using System;
+using System.IO;
+
+namespace NuGet.Server.Core
+{
+    public static class PackageFactory
+    {
+        public static IPackage Open(string fullPackagePath)
+        {
+            if (string.IsNullOrEmpty(fullPackagePath))
+            {
+                throw new ArgumentNullException(nameof(fullPackagePath));
+            }
+
+            var directoryName = Path.GetDirectoryName(fullPackagePath);
+            var fileName = Path.GetFileName(fullPackagePath);
+
+            var fileSystem = new PhysicalFileSystem(directoryName);
+
+            return new OptimizedZipPackage(
+                fileSystem,
+                fileName,
+                NullFileSystem.Instance);
+        }
+    }
+}

--- a/src/NuGet.Server.Core/Infrastructure/ServerPackageRepository.cs
+++ b/src/NuGet.Server.Core/Infrastructure/ServerPackageRepository.cs
@@ -236,7 +236,7 @@ namespace NuGet.Server.Core.Infrastructure
                     try
                     {
                         // Create package
-                        var package = new OptimizedZipPackage(_fileSystem, packageFile);
+                        var package = PackageFactory.Open(_fileSystem.GetFullPath(packageFile));
 
                         if (!CanPackageBeAddedWithoutLocking(package, shouldThrow: false))
                         {

--- a/src/NuGet.Server.Core/NuGet.Server.Core.csproj
+++ b/src/NuGet.Server.Core/NuGet.Server.Core.csproj
@@ -58,7 +58,9 @@
     </Compile>
     <Compile Include="Core\Constants.cs" />
     <Compile Include="Core\FrameworkNameExtensions.cs" />
+    <Compile Include="Core\NullFileSystem.cs" />
     <Compile Include="Core\PackageExtensions.cs" />
+    <Compile Include="Core\PackageFactory.cs" />
     <Compile Include="DataServices\IgnoreCaseForPackageIdInterceptor.cs" />
     <Compile Include="DataServices\NormalizeVersionInterceptor.cs" />
     <Compile Include="DataServices\ODataPackage.cs" />

--- a/src/NuGet.Server.V2/Controllers/NuGetODataController.cs
+++ b/src/NuGet.Server.V2/Controllers/NuGetODataController.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using System.Web.Http;
 using System.Web.Http.OData;
 using System.Web.Http.OData.Query;
+using NuGet.Server.Core;
 using NuGet.Server.Core.DataServices;
 using NuGet.Server.Core.Infrastructure;
 using NuGet.Server.V2.Model;
@@ -396,8 +397,7 @@ namespace NuGet.Server.V2.Controllers
                 }
             }
 
-            var package = new OptimizedZipPackage(temporaryFile);
-
+            var package = PackageFactory.Open(temporaryFile);
 
             HttpResponseMessage retValue;
             if (_authenticationService.IsAuthenticated(User, apiKey, package.Id))

--- a/test/NuGet.Server.Core.Tests/Core/PackageFactoryTest.cs
+++ b/test/NuGet.Server.Core.Tests/Core/PackageFactoryTest.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using System;
+using System.IO;
+using NuGet.Server.Core.Tests.Infrastructure;
+using Xunit;
+
+namespace NuGet.Server.Core.Tests.Core
+{
+    public class PackageFactoryTest
+    {
+        public class Open : IDisposable
+        {
+            private readonly TemporaryDirectory _directory;
+
+            public Open()
+            {
+                _directory = new TemporaryDirectory();
+            }
+
+            [Theory]
+            [InlineData(null)]
+            [InlineData("")]
+            public void RejectsInvalidPaths(string path)
+            {
+                var ex = Assert.Throws<ArgumentNullException>(
+                    () => PackageFactory.Open(path));
+                Assert.Equal("fullPackagePath", ex.ParamName);
+            }
+
+            [Fact]
+            public void InitializesPackageWithMetadata()
+            {
+                // Arrange
+                var path = Path.Combine(_directory, "package.nupkg");
+                TestData.CopyResourceToPath(TestData.PackageResource, path);
+
+                // Act
+                var package = PackageFactory.Open(path);
+
+                // Assert
+                Assert.Equal(TestData.PackageId, package.Id);
+                Assert.Equal(TestData.PackageVersion, package.Version);
+            }
+
+            [Fact]
+            public void InitializesPackageWithSupportedFrameworks()
+            {
+                // Arrange
+                var path = Path.Combine(_directory, "package.nupkg");
+                TestData.CopyResourceToPath(TestData.PackageResource, path);
+
+                // Act
+                var package = PackageFactory.Open(path);
+
+                // Assert
+                var frameworks = package.GetSupportedFrameworks();
+                var framework = Assert.Single(frameworks);
+                Assert.Equal(VersionUtility.ParseFrameworkName("net40-client"), framework);
+            }
+
+            [Fact]
+            public void InitializesPackageWhichCanBeCheckedForSymbols()
+            {
+                // Arrange
+                var path = Path.Combine(_directory, "package.nupkg");
+                TestData.CopyResourceToPath(TestData.PackageResource, path);
+
+                // Act
+                var package = PackageFactory.Open(path);
+
+                // Assert
+                Assert.False(package.IsSymbolsPackage(), "The provided package is not a symbols package.");
+            }
+
+            public void Dispose()
+            {
+                _directory?.Dispose();
+            }
+        }
+    }
+}

--- a/test/NuGet.Server.Core.Tests/NuGet.Server.Core.Tests.csproj
+++ b/test/NuGet.Server.Core.Tests/NuGet.Server.Core.Tests.csproj
@@ -81,6 +81,7 @@
   <ItemGroup>
     <Compile Include="ApiKeyPackageAuthenticationServiceTest.cs" />
     <Compile Include="ClientCompatibilityFactoryTests.cs" />
+    <Compile Include="Core\PackageFactoryTest.cs" />
     <Compile Include="IdAndVersionEqualityComparerTest.cs" />
     <Compile Include="IgnoreCaseForPackageIdInterceptorTest.cs" />
     <Compile Include="Infrastructure\FuncSettingsProvider.cs" />


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/5230 by introducing a null file system abstraction that no-ops when `OptimizedZipArchive` tries to extract the package content.

I decided to keep using the `OptimizedZipPackage` because it does have a cache of the file listing which lives as long as the process does.
https://github.com/NuGet/NuGet2/blob/57bcfab043703778f242080fedc7237d36a6af98/src/Core/Packages/OptimizedZipPackage.cs#L27-L28

Rohit, you were the last to make changes to `OptimizedZipPackage` so I added you.