### PR TITLE
Configurable cache file name

### DIFF
--- a/samples/NuGet.Server.V2.Samples.OwinHost/DictionarySettingsProvider.cs
+++ b/samples/NuGet.Server.V2.Samples.OwinHost/DictionarySettingsProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+using System;
 using System.Collections.Generic;
 using NuGet.Server.Core.Infrastructure;
 
@@ -7,9 +8,9 @@ namespace NuGet.Server.V2.Samples.OwinHost
 {
     public class DictionarySettingsProvider : ISettingsProvider
     {
-        readonly Dictionary<string, bool> _settings;
+        readonly Dictionary<string, object> _settings;
 
-        public DictionarySettingsProvider(Dictionary<string, bool> settings)
+        public DictionarySettingsProvider(Dictionary<string, object> settings)
         {
             _settings = settings;
         }
@@ -18,8 +19,13 @@ namespace NuGet.Server.V2.Samples.OwinHost
         public bool GetBoolSetting(string key, bool defaultValue)
         {
             System.Diagnostics.Debug.WriteLine("getSetting: " + key);
-            return _settings.ContainsKey(key) ? _settings[key] : defaultValue;
+            return _settings.ContainsKey(key) ? Convert.ToBoolean(_settings[key]) : defaultValue;
 
+        }
+
+        public string GetStringSetting(string key, string defaultValue)
+        {
+            return _settings.ContainsKey(key) ? Convert.ToString(_settings[key]) : defaultValue;
         }
     }
 }

--- a/samples/NuGet.Server.V2.Samples.OwinHost/Program.cs
+++ b/samples/NuGet.Server.V2.Samples.OwinHost/Program.cs
@@ -24,7 +24,7 @@ namespace NuGet.Server.V2.Samples.OwinHost
 
             // Set up a common settingsProvider to be used by all repositories. 
             // If a setting is not present in dictionary default value will be used.
-            var settings = new Dictionary<string, bool>();
+            var settings = new Dictionary<string, object>();
             settings.Add("enableDelisting", false);                         //default=false
             settings.Add("enableFrameworkFiltering", false);                //default=false
             settings.Add("ignoreSymbolsPackages", true);                    //default=false

--- a/src/NuGet.Server.Core/Infrastructure/DefaultSettingsProvider.cs
+++ b/src/NuGet.Server.Core/Infrastructure/DefaultSettingsProvider.cs
@@ -8,5 +8,10 @@ namespace NuGet.Server.Core.Infrastructure
         {
             return defaultValue;
         }
+
+        public string GetStringSetting(string key, string defaultValue)
+        {
+            return defaultValue;
+        }
     }
 }

--- a/src/NuGet.Server.Core/Infrastructure/ISettingsProvider.cs
+++ b/src/NuGet.Server.Core/Infrastructure/ISettingsProvider.cs
@@ -5,5 +5,6 @@ namespace NuGet.Server.Core.Infrastructure
     public interface ISettingsProvider
     {
         bool GetBoolSetting(string key, bool defaultValue);
+        string GetStringSetting(string key, string defaultValue);
     }
 }

--- a/src/NuGet.Server.Core/Infrastructure/ServerPackageRepository.cs
+++ b/src/NuGet.Server.Core/Infrastructure/ServerPackageRepository.cs
@@ -58,7 +58,7 @@ namespace NuGet.Server.Core.Infrastructure
             _runBackgroundTasks = true;
             _settingsProvider = settingsProvider ?? new DefaultSettingsProvider();
             _logger = logger ?? new TraceLogger();
-            _serverPackageCache = InitializeServerPackageStore();
+            _serverPackageCache = InitializeServerPackageCache();
             _serverPackageStore = new ServerPackageStore(
                 _fileSystem,
                 new ExpandedPackageRepository(_fileSystem, hashProvider),
@@ -81,7 +81,7 @@ namespace NuGet.Server.Core.Infrastructure
             _runBackgroundTasks = runBackgroundTasks;
             _settingsProvider = settingsProvider ?? new DefaultSettingsProvider();
             _logger = logger ?? new TraceLogger();
-            _serverPackageCache = InitializeServerPackageStore();
+            _serverPackageCache = InitializeServerPackageCache();
             _serverPackageStore = new ServerPackageStore(
                 _fileSystem,
                 innerRepository,
@@ -107,7 +107,7 @@ namespace NuGet.Server.Core.Infrastructure
 
         private string CacheFileName => _settingsProvider.GetStringSetting("cacheFileName", null);
 
-        private ServerPackageCache InitializeServerPackageStore()
+        private ServerPackageCache InitializeServerPackageCache()
         {
             return new ServerPackageCache(_fileSystem, ResolveCacheFileName());
         }

--- a/src/NuGet.Server.Core/Infrastructure/ServerPackageRepository.cs
+++ b/src/NuGet.Server.Core/Infrastructure/ServerPackageRepository.cs
@@ -124,7 +124,9 @@ namespace NuGet.Server.Core.Infrastructure
             }
 
             if (fileName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+            {
                 return fileName;
+            }
 
             return fileName + suffix;
         }

--- a/src/NuGet.Server.Core/Infrastructure/ServerPackageRepository.cs
+++ b/src/NuGet.Server.Core/Infrastructure/ServerPackageRepository.cs
@@ -123,6 +123,15 @@ namespace NuGet.Server.Core.Infrastructure
                 return Environment.MachineName.ToLowerInvariant() + suffix;
             }
 
+            if (fileName.LastIndexOfAny(Path.GetInvalidFileNameChars()) > 0)
+            {
+                var message = string.Format(Strings.Error_InvalidCacheFileName, fileName);
+
+                _logger.Log(LogLevel.Error, message);
+
+                throw new InvalidOperationException(message);
+            }
+
             if (fileName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
             {
                 return fileName;

--- a/src/NuGet.Server.Core/Infrastructure/ServerPackageRepository.cs
+++ b/src/NuGet.Server.Core/Infrastructure/ServerPackageRepository.cs
@@ -105,9 +105,28 @@ namespace NuGet.Server.Core.Infrastructure
         private bool EnableFileSystemMonitoring =>
             _settingsProvider.GetBoolSetting("enableFileSystemMonitoring", true);
 
+        private string CacheFileName => _settingsProvider.GetStringSetting("cacheFileName", null);
+
         private ServerPackageCache InitializeServerPackageStore()
         {
-            return new ServerPackageCache(_fileSystem, Environment.MachineName.ToLowerInvariant() + ".cache.bin");
+            return new ServerPackageCache(_fileSystem, ResolveCacheFileName());
+        }
+
+        private string ResolveCacheFileName()
+        {
+            var fileName = CacheFileName;
+            const string suffix = ".cache.bin";
+
+            if (String.IsNullOrWhiteSpace(fileName))
+            {
+                // Default file name
+                return Environment.MachineName.ToLowerInvariant() + suffix;
+            }
+
+            if (fileName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+                return fileName;
+
+            return fileName + suffix;
         }
 
         /// <summary>

--- a/src/NuGet.Server.Core/Strings.Designer.cs
+++ b/src/NuGet.Server.Core/Strings.Designer.cs
@@ -61,6 +61,15 @@ namespace NuGet.Server.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Configured cache file name &apos;{0}&apos; is invalid. Keep it simple; No paths allowed..
+        /// </summary>
+        internal static string Error_InvalidCacheFileName {
+            get {
+                return ResourceManager.GetString("Error_InvalidCacheFileName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Package {0} already exists. The server is configured to not allow overwriting packages that already exist..
         /// </summary>
         internal static string Error_PackageAlreadyExists {

--- a/src/NuGet.Server.Core/Strings.resx
+++ b/src/NuGet.Server.Core/Strings.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Error_InvalidCacheFileName" xml:space="preserve">
+    <value>Configured cache file name '{0}' is invalid. Keep it simple; No paths allowed.</value>
+  </data>
   <data name="Error_PackageAlreadyExists" xml:space="preserve">
     <value>Package {0} already exists. The server is configured to not allow overwriting packages that already exist.</value>
   </data>

--- a/src/NuGet.Server/Infrastructure/WebConfigSettingsProvider.cs
+++ b/src/NuGet.Server/Infrastructure/WebConfigSettingsProvider.cs
@@ -28,5 +28,11 @@ namespace NuGet.Server.Infrastructure
             bool value;
             return !bool.TryParse(settings[key], out value) ? defaultValue : value;
         }
+
+        public string GetStringSetting(string key, string defaultValue)
+        {
+            var settings = _getSettings();
+            return settings[key] ?? defaultValue;
+        }
     }
 }

--- a/src/NuGet.Server/Web.config
+++ b/src/NuGet.Server/Web.config
@@ -24,7 +24,8 @@
 
     <!--
     Change the name of the internal cache file. Default is machine name (System.Environment.MachineName).
-        -->
+    This is the name of the cache file in the packages folder. No paths allowed.
+    -->
     <add key="cacheFileName" value="" />
 
     <!--

--- a/src/NuGet.Server/Web.config
+++ b/src/NuGet.Server/Web.config
@@ -23,6 +23,11 @@
     <add key="packagesPath" value="" />
 
     <!--
+    Change the name of the internal cache file. Default is machine name (System.Environment.MachineName).
+        -->
+    <add key="cacheFileName" value="" />
+
+    <!--
     Set allowOverrideExistingPackageOnPush to false to mimic NuGet.org's behaviour (do not allow overwriting packages with same id + version).
     -->
     <add key="allowOverrideExistingPackageOnPush" value="false" />

--- a/test/NuGet.Server.Core.Tests/Infrastructure/FuncSettingsProvider.cs
+++ b/test/NuGet.Server.Core.Tests/Infrastructure/FuncSettingsProvider.cs
@@ -7,8 +7,8 @@ namespace NuGet.Server.Core.Tests.Infrastructure
 {
     class FuncSettingsProvider : ISettingsProvider
     {
-        readonly Func<string, bool, bool> _getSetting;
-        internal FuncSettingsProvider(Func<string,bool,bool> getSetting)
+        readonly Func<string, object, object> _getSetting;
+        internal FuncSettingsProvider(Func<string,object,object> getSetting)
         {
             if (getSetting == null)
             {
@@ -20,7 +20,12 @@ namespace NuGet.Server.Core.Tests.Infrastructure
 
         public bool GetBoolSetting(string key, bool defaultValue)
         {
-            return _getSetting(key, defaultValue);
+            return Convert.ToBoolean(_getSetting(key, defaultValue));
+        }
+
+        public string GetStringSetting(string key, string defaultValue)
+        {
+            return Convert.ToString(_getSetting(key, defaultValue));
         }
     }
 }

--- a/test/NuGet.Server.Core.Tests/Infrastructure/FuncSettingsProvider.cs
+++ b/test/NuGet.Server.Core.Tests/Infrastructure/FuncSettingsProvider.cs
@@ -8,7 +8,7 @@ namespace NuGet.Server.Core.Tests.Infrastructure
     class FuncSettingsProvider : ISettingsProvider
     {
         readonly Func<string, object, object> _getSetting;
-        internal FuncSettingsProvider(Func<string,object,object> getSetting)
+        internal FuncSettingsProvider(Func<string, object, object> getSetting)
         {
             if (getSetting == null)
             {

--- a/test/NuGet.Server.Core.Tests/ServerPackageRepositoryTest.cs
+++ b/test/NuGet.Server.Core.Tests/ServerPackageRepositoryTest.cs
@@ -23,7 +23,7 @@ namespace NuGet.Server.Core.Tests
         public static async Task<ServerPackageRepository> CreateServerPackageRepositoryAsync(
             string path,
             Action<ExpandedPackageRepository> setupRepository = null,
-            Func<string, bool, bool> getSetting = null)
+            Func<string, object, object> getSetting = null)
         {
             var fileSystem = new PhysicalFileSystem(path);
             var expandedPackageRepository = new ExpandedPackageRepository(fileSystem);
@@ -514,7 +514,7 @@ namespace NuGet.Server.Core.Tests
             using (var temporaryDirectory = new TemporaryDirectory())
             {
                 // Arrange
-                var getSetting = enableDelisting ? EnableDelisting : (Func<string, bool, bool>)null;
+                var getSetting = enableDelisting ? EnableDelisting : (Func<string, object, object>)null;
                 var serverRepository = await CreateServerPackageRepositoryAsync(temporaryDirectory.Path, repository =>
                 {
                     repository.AddPackage(CreatePackage("test", "2.0-alpha"));
@@ -548,7 +548,7 @@ namespace NuGet.Server.Core.Tests
             using (var temporaryDirectory = new TemporaryDirectory())
             {
                 // Arrange
-                var getSetting = enableDelisting ? EnableDelisting : (Func<string, bool, bool>)null;
+                var getSetting = enableDelisting ? EnableDelisting : (Func<string, object, object>)null;
                 var serverRepository = await CreateServerPackageRepositoryAsync(temporaryDirectory.Path, repository =>
                 {
                     repository.AddPackage(CreatePackage("test", "2.0-alpha"));
@@ -603,7 +603,7 @@ namespace NuGet.Server.Core.Tests
             using (var temporaryDirectory = new TemporaryDirectory())
             {
                 // Arrange
-                var getSetting = enableDelisting ? EnableDelisting : (Func<string, bool, bool>)null;
+                var getSetting = enableDelisting ? EnableDelisting : (Func<string, object, object>)null;
                 var serverRepository = await CreateServerPackageRepositoryAsync(temporaryDirectory.Path, repository =>
                 {
                     repository.AddPackage(CreatePackage("test1", "1.0.0"));
@@ -634,7 +634,7 @@ namespace NuGet.Server.Core.Tests
             using (var temporaryDirectory = new TemporaryDirectory())
             {
                 // Arrange
-                var getSetting = enableDelisting ? EnableDelisting : (Func<string, bool, bool>)null;
+                var getSetting = enableDelisting ? EnableDelisting : (Func<string, object, object>)null;
                 var serverRepository = await CreateServerPackageRepositoryAsync(temporaryDirectory.Path, repository =>
                 {
                     repository.AddPackage(CreatePackage("test", "1.11"));
@@ -879,7 +879,7 @@ namespace NuGet.Server.Core.Tests
             return outputPackage;
         }
 
-        private static bool EnableDelisting(string key, bool defaultValue)
+        private static object EnableDelisting(string key, object defaultValue)
         {
             if (key == "enableDelisting")
             {

--- a/test/NuGet.Server.Core.Tests/ServerPackageRepositoryTest.cs
+++ b/test/NuGet.Server.Core.Tests/ServerPackageRepositoryTest.cs
@@ -821,15 +821,7 @@ namespace NuGet.Server.Core.Tests
             {
                 ServerPackageRepository serverRepository = await CreateServerPackageRepositoryAsync(
                     temporaryDirectory.Path,
-                    getSetting: (key, defaultValue) =>
-                    {
-                        if (key == "cacheFileName")
-                        {
-                            return fileNameFromConfig;
-                        }
-
-                        return defaultValue;
-                    });
+                    getSetting: (key, defaultValue) => key == "cacheFileName" ? fileNameFromConfig : defaultValue);
 
                 string expectedCacheFileName = Path.Combine(serverRepository.Source, Environment.MachineName.ToLowerInvariant() + ".cache.bin");
 
@@ -844,15 +836,7 @@ namespace NuGet.Server.Core.Tests
             {
                 ServerPackageRepository serverRepository = await CreateServerPackageRepositoryAsync(
                     temporaryDirectory.Path,
-                    getSetting: (key, defaultValue) =>
-                    {
-                        if (key == "cacheFileName")
-                        {
-                            return "CustomFileName.cache.bin";
-                        }
-
-                        return defaultValue;
-                    });
+                    getSetting: (key, defaultValue) => key == "cacheFileName" ? "CustomFileName.cache.bin" : defaultValue);
 
                 string expectedCacheFileName = Path.Combine(serverRepository.Source, "CustomFileName.cache.bin");
 
@@ -867,15 +851,7 @@ namespace NuGet.Server.Core.Tests
             {
                 ServerPackageRepository serverRepository = await CreateServerPackageRepositoryAsync(
                     temporaryDirectory.Path,
-                    getSetting: (key, defaultValue) =>
-                    {
-                        if (key == "cacheFileName")
-                        {
-                            return "CustomFileName";
-                        }
-
-                        return defaultValue;
-                    });
+                    getSetting: (key, defaultValue) => key == "cacheFileName" ? "CustomFileName" : defaultValue);
 
                 string expectedCacheFileName = Path.Combine(serverRepository.Source, "CustomFileName.cache.bin");
 
@@ -890,19 +866,11 @@ namespace NuGet.Server.Core.Tests
         {
             using (var temporaryDirectory = new TemporaryDirectory())
             {
-                Func<Task> code = () => CreateServerPackageRepositoryAsync(
+                Task Code() => CreateServerPackageRepositoryAsync(
                     temporaryDirectory.Path,
-                    getSetting: (key, defaultValue) =>
-                    {
-                        if (key == "cacheFileName")
-                        {
-                            return invlaidCacheFileName;
-                        }
+                    getSetting: (key, defaultValue) => key == "cacheFileName" ? invlaidCacheFileName : defaultValue);
 
-                        return defaultValue;
-                    });
-
-                await Assert.ThrowsAsync<InvalidOperationException>(code);
+                await Assert.ThrowsAsync<InvalidOperationException>(Code);
             }
         }
 
@@ -911,20 +879,12 @@ namespace NuGet.Server.Core.Tests
         {
             using (var temporaryDirectory = new TemporaryDirectory())
             {
-                Func<Task> code = () => CreateServerPackageRepositoryAsync(
+                Task Code() => CreateServerPackageRepositoryAsync(
                     temporaryDirectory.Path,
-                    getSetting: (key, defaultValue) =>
-                    {
-                        if (key == "cacheFileName")
-                        {
-                            return "foo:bar/baz";
-                        }
-
-                        return defaultValue;
-                    });
+                    getSetting: (key, defaultValue) => key == "cacheFileName" ? "foo:bar/baz" : defaultValue);
 
                 var expectedMessage = "Configured cache file name 'foo:bar/baz' is invalid. Keep it simple; No paths allowed.";
-                Assert.Equal(expectedMessage, (await Assert.ThrowsAsync<InvalidOperationException>(code)).Message);
+                Assert.Equal(expectedMessage, (await Assert.ThrowsAsync<InvalidOperationException>(Code)).Message);
             }
         }
 


### PR DESCRIPTION
Background for pull request: I have two nuget server sites sharing the same package repository folder. One public with authentication, and one internal. In this scenario I get file lock errors on the cache file, so I need to be able to configure different cache files for each site.