### PR TITLE
Normalize directories before comparing paths in file changed event in order to avoid erroneous cache invalidation in a multi-node deploymeny 

### DIFF
--- a/src/NuGet.Server.Core/Infrastructure/ServerPackageRepository.cs
+++ b/src/NuGet.Server.Core/Infrastructure/ServerPackageRepository.cs
@@ -32,6 +32,7 @@ namespace NuGet.Server.Core.Infrastructure
 
         private readonly bool _runBackgroundTasks;
         private FileSystemWatcher _fileSystemWatcher;
+        private string _watchDirectory;
         private bool _isFileSystemWatcherSuppressed;
         private bool _needsRebuild;
 
@@ -548,6 +549,9 @@ namespace NuGet.Server.Core.Infrastructure
                     IncludeSubdirectories = true,
                 };
 
+                //Keep the normalized watch path.
+                _watchDirectory = Path.GetFullPath(_fileSystemWatcher.Path);
+
                 _fileSystemWatcher.Changed += FileSystemChangedAsync;
                 _fileSystemWatcher.Created += FileSystemChangedAsync;
                 _fileSystemWatcher.Deleted += FileSystemChangedAsync;
@@ -576,6 +580,8 @@ namespace NuGet.Server.Core.Infrastructure
 
                 _logger.Log(LogLevel.Verbose, "Destroyed FileSystemWatcher - no longer monitoring {0}.", Source);
             }
+
+            _watchDirectory = null;
         }
 
 
@@ -593,11 +599,16 @@ namespace NuGet.Server.Core.Infrastructure
 
                 _logger.Log(LogLevel.Verbose, "File system changed. File: {0} - Change: {1}", e.Name, e.ChangeType);
 
-                var changedDirectory = Path.GetFullPath(Path.GetDirectoryName(e.FullPath) ?? throw new InvalidOperationException());
-                var watchDirectory = Path.GetFullPath(_fileSystemWatcher.Path);
+                var changedDirectory = Path.GetDirectoryName(e.FullPath);
+                if (changedDirectory == null || _watchDirectory == null)
+                {
+                    return;
+                }
+
+                changedDirectory = Path.GetFullPath(changedDirectory);                
 
                 // 1) If a .nupkg is dropped in the root, add it as a package
-                if (string.Equals(changedDirectory, watchDirectory, StringComparison.OrdinalIgnoreCase)
+                if (string.Equals(changedDirectory, _watchDirectory, StringComparison.OrdinalIgnoreCase)
                     && string.Equals(Path.GetExtension(e.Name), ".nupkg", StringComparison.OrdinalIgnoreCase))
                 {
                     // When a package is dropped into the server packages root folder, add it to the repository.
@@ -605,7 +616,7 @@ namespace NuGet.Server.Core.Infrastructure
                 }
 
                 // 2) If a file is updated in a subdirectory, *or* a folder is deleted, invalidate the cache
-                if ((!string.Equals(changedDirectory, watchDirectory, StringComparison.OrdinalIgnoreCase) && File.Exists(e.FullPath))
+                if ((!string.Equals(changedDirectory, _watchDirectory, StringComparison.OrdinalIgnoreCase) && File.Exists(e.FullPath))
                     || e.ChangeType == WatcherChangeTypes.Deleted)
                 {
                     // TODO: invalidating *all* packages for every nupkg change under this folder seems more expensive than it should.

--- a/src/NuGet.Server.Core/Infrastructure/ServerPackageRepository.cs
+++ b/src/NuGet.Server.Core/Infrastructure/ServerPackageRepository.cs
@@ -593,8 +593,11 @@ namespace NuGet.Server.Core.Infrastructure
 
                 _logger.Log(LogLevel.Verbose, "File system changed. File: {0} - Change: {1}", e.Name, e.ChangeType);
 
+                var changedDirectory = Path.GetFullPath(Path.GetDirectoryName(e.FullPath) ?? throw new InvalidOperationException());
+                var watchDirectory = Path.GetFullPath(_fileSystemWatcher.Path);
+
                 // 1) If a .nupkg is dropped in the root, add it as a package
-                if (string.Equals(Path.GetDirectoryName(e.FullPath), _fileSystemWatcher.Path, StringComparison.OrdinalIgnoreCase)
+                if (string.Equals(changedDirectory, watchDirectory, StringComparison.OrdinalIgnoreCase)
                     && string.Equals(Path.GetExtension(e.Name), ".nupkg", StringComparison.OrdinalIgnoreCase))
                 {
                     // When a package is dropped into the server packages root folder, add it to the repository.
@@ -602,7 +605,7 @@ namespace NuGet.Server.Core.Infrastructure
                 }
 
                 // 2) If a file is updated in a subdirectory, *or* a folder is deleted, invalidate the cache
-                if ((!string.Equals(Path.GetDirectoryName(e.FullPath), _fileSystemWatcher.Path, StringComparison.OrdinalIgnoreCase) && File.Exists(e.FullPath))
+                if ((!string.Equals(changedDirectory, watchDirectory, StringComparison.OrdinalIgnoreCase) && File.Exists(e.FullPath))
                     || e.ChangeType == WatcherChangeTypes.Deleted)
                 {
                     // TODO: invalidating *all* packages for every nupkg change under this folder seems more expensive than it should.


### PR DESCRIPTION
# Issue

I am using NuGet.Server in multi node (10 nodes) deployment model, all the nodes pointing to the same packages file share. For each node pointing at the same share, a cache file is created with the name of the machine.

In the file system changed event, when a file is changed in a subdirectory, the cache is invalidated (10 caches in my case). The problem is that in my scenario, when the cache file itself is updated, the nuget server fails to recognize the updated cache is located in the root folder, so it should not trigger invalidation of the other caches monitoring the same folder.

The consequence is that I always have 1 valid cache and 9 empty caches. This causes severe performance issues because the cache is always rebuilt and we have thousands of packages.

The application allows configuring the packages folder via configuration and using path combine, so in my case the path ended up in this format, which is a valid path.
`C:\Projects\NuGet.Server\src\NuGet.Server\./Packages`

But the folder comparison compares: `Path.GetDirectoryName(e.FullPath) ` with `_fileSystemWatcher.Path`.

The first value is computed `C:\Projects\NuGet.Server\src\NuGet.Server\.\Packages` while the second is computed as `C:\Projects\NuGet.Server\src\NuGet.Server\./Packages` and the string comparison fails.

# Fix

The fix was to normalize the path by calling Path.GetFullPath on both comparison terms. If the path format it non-normalized, it will be normalized, so the comparison is correct.