### PR TITLE
Added option downloadCacheControlMaxAge so that CDN can cache package downloads

### DIFF
--- a/src/NuGet.Server/Controllers/PackagesODataController.cs
+++ b/src/NuGet.Server/Controllers/PackagesODataController.cs
@@ -20,7 +20,8 @@ namespace NuGet.Server.DataServices
 
         protected PackagesODataController(IServiceResolver serviceResolver)
             : base(serviceResolver.Resolve<IServerPackageRepository>(),
-                   serviceResolver.Resolve<IPackageAuthenticationService>())
+                   serviceResolver.Resolve<IPackageAuthenticationService>(),
+                   serviceResolver.Resolve<ISettingsProvider>())
         {
             _maxPageSize = 100;
         }


### PR DESCRIPTION
`NuGetODataController` needs to know a parameter from web.config.
I did this implementation by using `ISettingsProvider` as a service.

If you prefer, it might be better to create a separate interface service (i.e. `IWebCacheService.MaxAge` or even a more general `IWebSettingsService.MaxAge`).
Let me know if you would prefer it that way, and what interface name.