### PR TITLE
Add route to match older Nuget.Server uploads

### DIFF
--- a/src/NuGet.Server.V2/NuGetV2WebApiEnabler.cs
+++ b/src/NuGet.Server.V2/NuGetV2WebApiEnabler.cs
@@ -53,6 +53,13 @@ namespace NuGet.Server.V2
                  constraints: new { httpMethod = new HttpMethodConstraint(HttpMethod.Delete) }
              );
 
+            config.Routes.MapHttpRoute(
+                 name: "apiv2package_upload",
+                 routeTemplate: "api/v2/package",
+                 defaults: new { controller = oDatacontrollerName, action = "UploadPackage" },
+                 constraints: new { httpMethod = new HttpMethodConstraint(HttpMethod.Put) }
+             );
+
             config.Routes.MapODataServiceRoute(routeName, routeUrlRoot, oDataModel, new CountODataPathHandler(), conventions);
             return config;
         }


### PR DESCRIPTION
Between NuGet.Server v2.8.50926.602 and NuGet.Server v3.1.2.0 the route to push a package was changed from `/api/v2/packages` to `/nuget`. 

When using nuget.exe, if using the root url it will append `api/v2/packages`.
For example, 

```
.\Nuget.exe push "{thing}.nupkg" -s http://localhost:40221 -Verbosity detailed
Pushing {package} 1.2.3 to 'http://localhost:40221'...
PUT http://localhost:40221/api/v2/package/
```

This change will allow users to continue to push packages to `api/v2/packages` so they don't have to edit their existing deployment scripts when doing a Nuget.Server upgrade. 