### PR TITLE
Don't enable the legacy push route by default

### DIFF
--- a/src/NuGet.Server/App_Start/NuGetODataConfig.cs
+++ b/src/NuGet.Server/App_Start/NuGetODataConfig.cs
@@ -28,7 +28,12 @@ namespace NuGet.Server.App_Start
 
         public static void Initialize(HttpConfiguration config, string controllerName)
         {
-            NuGetV2WebApiEnabler.UseNuGetV2WebApiFeed(config, "NuGetDefault", "nuget", controllerName);
+            NuGetV2WebApiEnabler.UseNuGetV2WebApiFeed(
+                config,
+                "NuGetDefault",
+                "nuget",
+                controllerName,
+                enableLegacyPushRoute: true);
 
             config.Services.Replace(typeof(IExceptionLogger), new TraceExceptionLogger());
 

--- a/src/NuGet.Server/App_Start/NuGetODataConfig.cs.pp
+++ b/src/NuGet.Server/App_Start/NuGetODataConfig.cs.pp
@@ -11,14 +11,19 @@ using NuGet.Server.V2;
 namespace $rootnamespace$.App_Start 
 {
     public static class NuGetODataConfig 
-	{
+    {
         public static void Start() 
-		{
+        {
             ServiceResolver.SetServiceResolver(new DefaultServiceResolver());
 
             var config = GlobalConfiguration.Configuration;
 
-            NuGetV2WebApiEnabler.UseNuGetV2WebApiFeed(config, "NuGetDefault", "nuget", "PackagesOData");
+            NuGetV2WebApiEnabler.UseNuGetV2WebApiFeed(
+                config,
+                "NuGetDefault",
+                "nuget",
+                "PackagesOData",
+                enableLegacyPushRoute: true);
 
             config.Services.Replace(typeof(IExceptionLogger), new TraceExceptionLogger());
 

--- a/test/NuGet.Server.Tests/TestablePackagesODataController.cs
+++ b/test/NuGet.Server.Tests/TestablePackagesODataController.cs
@@ -7,6 +7,9 @@ namespace NuGet.Server.Tests
 {
     public class TestablePackagesODataController : PackagesODataController
     {
+        public static readonly string Name = nameof(TestablePackagesODataController)
+            .Substring(0, nameof(TestablePackagesODataController).Length - "Controller".Length);
+
         public TestablePackagesODataController(IServiceResolver serviceResolver)
             : base(serviceResolver)
         {


### PR DESCRIPTION
This only affects the NuGetV2WebApiEnabler.UseNuGetV2WebApiFeed API. NuGet.Server still enables the legacy push route by default since it already assumes there is only one feed in the application.

Address https://github.com/NuGet/NuGetGallery/issues/7008

/cc @Levente0xFFFF