### PR TITLE
Force package metadata URLs to be parsed as absolute URIs

### DIFF
--- a/src/NuGet.Server.Core/Infrastructure/JsonNetPackagesSerializer.cs
+++ b/src/NuGet.Server.Core/Infrastructure/JsonNetPackagesSerializer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -18,7 +19,8 @@ namespace NuGet.Server.Core.Infrastructure
         private readonly JsonSerializer _serializer = new JsonSerializer
         {
             Formatting = Formatting.None,
-            NullValueHandling = NullValueHandling.Ignore
+            NullValueHandling = NullValueHandling.Ignore,
+            Converters = { new AbsoluteUriConverter() },
         };
 
         public void Serialize(IEnumerable<ServerPackage> packages, Stream stream)
@@ -49,6 +51,55 @@ namespace NuGet.Server.Core.Infrastructure
                 }
                 
                 return packages.Packages;
+            }
+        }
+
+        /// <summary>
+        /// This is necessary because Newtonsoft.Json creates <see cref="Uri"/> instances with
+        /// <see cref="UriKind.RelativeOrAbsolute"/> which treats UNC paths as relative. NuGet.Core uses
+        /// <see cref="UriKind.Absolute"/> which treats UNC paths as absolute. For more details, see:
+        /// https://github.com/JamesNK/Newtonsoft.Json/issues/2128
+        /// </summary>
+        private class AbsoluteUriConverter : JsonConverter
+        {
+            public override bool CanConvert(Type objectType)
+            {
+                return objectType == typeof(Uri);
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                if (reader.TokenType == JsonToken.Null)
+                {
+                    return null;
+                }
+                else if (reader.TokenType == JsonToken.String)
+                {
+                    return new Uri((string)reader.Value, UriKind.Absolute);
+                }
+
+                throw new JsonSerializationException("The JSON value must be a string.");
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                if (value == null)
+                {
+                    writer.WriteNull();
+                    return;
+                }
+
+                if (!(value is Uri uriValue))
+                {
+                    throw new JsonSerializationException("The value must be a URI.");
+                }
+
+                if (!uriValue.IsAbsoluteUri)
+                {
+                    throw new JsonSerializationException("The URI value must be an absolute Uri. Relative URI instances are not allowed.");
+                }
+
+                writer.WriteValue(uriValue.OriginalString);
             }
         }
     }


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/7414.
See https://github.com/JamesNK/Newtonsoft.Json/issues/2128 for more context.

NuGet.Core always parses things as absolute URIs so it's not possible for strings only parsable as relative to it into the system.

The weird case is something like `//fileserver/Framework/NuGet/server.png` which is parsable as both relative and absolute.