### PR TITLE
Adding artifacts directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,4 @@ nuget.exe
 Results.*.xml
 !**/TestData/*.nupkg
 .vs
+artifacts/*


### PR DESCRIPTION
`artifacts` directory contains the build output and needs to be ignored by git.
